### PR TITLE
feat: add autopilot daily sync pilot

### DIFF
--- a/generate_response.py
+++ b/generate_response.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""CLI helper for agents to generate AI-powered responses using LLM APIs.
+
+Usage:
+    python generate_response.py --agent-name "BlackDog" \\
+        --from-name "PinkPond" --subject "Strategic Planning" \\
+        --body "Let's discuss Q1 strategy..." \\
+        [--model "claude-3-5-sonnet-20241022"]
+
+Returns JSON with generated response.
+Reads agent configuration from agent_config.json for per-agent model settings.
+"""
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from mcp_agent_mail.llm import complete_system_user
+
+
+# Load agent configuration
+CONFIG_FILE = Path(__file__).parent / "agent_config.json"
+
+def load_agent_config():
+    """Load agent configuration from JSON file."""
+    try:
+        if CONFIG_FILE.exists():
+            with open(CONFIG_FILE) as f:
+                return json.load(f)
+    except Exception:
+        pass
+    return {"agents": {}, "defaults": {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 1000}}
+
+
+# Agent system prompts
+AGENT_PROMPTS = {
+    "BlackDog": {
+        "role": "CBO - Chief Brand Officer",
+        "prompt": """You are BlackDog, the Chief Brand Officer (CBO) for WIN Platform.
+
+Your responsibilities:
+- Brand strategy and positioning
+- Marketing campaigns and messaging
+- Brand consistency across all touchpoints
+- Market research and competitive analysis
+- Brand voice and guidelines
+
+Communication style:
+- Strategic and visionary
+- Data-driven with creative flair
+- Collaborative but decisive on brand matters
+- Clear, professional, and inspiring
+
+When responding to messages:
+1. Acknowledge the sender and their message
+2. Provide your brand/marketing perspective
+3. Offer actionable insights or recommendations
+4. Keep responses concise but valuable (2-3 paragraphs)
+5. Use markdown formatting for clarity
+6. Sign with your role
+
+Daily sync protocol:
+- If the subject contains "Daily Sync", include sections `## Commitments` (bullet list of accepted/declined tasks with ETAs) and `## Bead Adjustments` using `- BEAD_TXN: task_id=<id> delta=<int> reason="..."` entries.
+- Summarize risks/dependencies under `## Risks & Requests` if applicable.
+
+Respond to the message below as BlackDog would."""
+    },
+    "GreenPresident": {
+        "role": "President - Strategic Operations",
+        "prompt": """You are GreenPresident, the President for WIN Platform.
+
+Your responsibilities:
+- Drive cross-functional execution of the CEO's vision
+- Provide strategic alignment across departments
+- Translate executive directives into actionable plans
+- Coordinate stakeholder communication and priorities
+- Safeguard company cadence, culture, and operational excellence
+
+Communication style:
+- Decisive, pragmatic, and outcomes-focused
+- Synthesizes perspectives into clear direction
+- Empowers teams while holding them accountable
+- Communicates succinctly with an executive lens
+- Collaborates closely with the CEO while owning day-to-day alignment
+
+When responding to messages:
+1. Acknowledge the sender and their message
+2. Provide strategic direction or operational guidance
+3. Clarify decisions, tradeoffs, or next steps
+4. Keep responses focused on outcomes (2-3 paragraphs)
+5. Use markdown formatting for clarity
+6. Sign with your role
+
+Daily sync protocol:
+- If the subject contains "Daily Sync", include sections `## Commitments` (bullet list of decisions and owners with ETAs) and `## Bead Adjustments` using `- BEAD_TXN: task_id=<id> delta=<int> reason="..."` entries.
+- Close with `## Risks & Requests` when executive support is required.
+
+Respond to the message below as GreenPresident would."""
+    }
+}
+
+
+async def generate_response(agent_name: str, from_name: str, subject: str, body: str, model: str = None, thread_depth: int = 0, max_depth: int = 3) -> dict:
+    """Generate AI-powered response for an agent.
+
+    Args:
+        agent_name: Name of the agent (GreenPresident, BlackDog, etc.)
+        from_name: Name of the message sender
+        subject: Message subject
+        body: Message body
+        model: Optional model override. If not provided, uses agent config or defaults to gpt-4o-mini
+        thread_depth: Current depth of the conversation thread (for loop awareness)
+        max_depth: Maximum allowed depth before conversation stops
+
+    Returns:
+        Dict with success status and response details
+    """
+
+    # Load configuration
+    config = load_agent_config()
+
+    # Get agent prompt
+    agent_info = AGENT_PROMPTS.get(agent_name)
+    if not agent_info:
+        return {
+            "error": f"Unknown agent: {agent_name}",
+            "agent_name": agent_name
+        }
+
+    # Get model settings from config
+    agent_config = config.get("agents", {}).get(agent_name, {})
+    defaults = config.get("defaults", {})
+
+    # Determine which model to use (priority: CLI arg > agent config > defaults)
+    use_model = model or agent_config.get("model") or defaults.get("model", "gpt-4o-mini")
+    use_temperature = agent_config.get("temperature", defaults.get("temperature", 0.7))
+    use_max_tokens = agent_config.get("max_tokens", defaults.get("max_tokens", 1000))
+
+    system_prompt = agent_info["prompt"]
+
+    # Add loop awareness context
+    loop_context = ""
+    if thread_depth > 0:
+        loop_context = f"""
+
+**Conversation Context:** This is message {thread_depth + 1} in an ongoing thread (limit: {max_depth} messages). """
+        if thread_depth >= max_depth - 1:
+            loop_context += "This is the final response in this thread - be concise and conclusive."
+        elif thread_depth >= (max_depth * 0.6):
+            loop_context += "Approaching thread limit - focus on key points and actionable items."
+
+    # Construct user message
+    user_message = f"""From: {from_name}
+Subject: {subject}
+
+{body}{loop_context}
+
+---
+
+Generate a response as {agent_name} ({agent_info['role']})."""
+
+    try:
+        # Call LLM API (via LiteLLM - supports OpenAI, Anthropic, etc.)
+        result = await complete_system_user(
+            system=system_prompt,
+            user=user_message,
+            model=use_model,
+            temperature=use_temperature,
+            max_tokens=use_max_tokens
+        )
+
+        return {
+            "success": True,
+            "agent_name": agent_name,
+            "role": agent_info["role"],
+            "response_body": result.content,
+            "model": result.model,
+            "provider": result.provider
+        }
+    except Exception as e:
+        return {
+            "error": str(e),
+            "agent_name": agent_name,
+            "details": "Check ANTHROPIC_API_KEY in .env file"
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate AI-powered agent responses",
+        epilog="Model is read from agent_config.json unless overridden with --model"
+    )
+    parser.add_argument("--agent-name", required=True, help="Agent name (GreenPresident, BlackDog)")
+    parser.add_argument("--from-name", required=True, help="Sender name")
+    parser.add_argument("--subject", required=True, help="Message subject")
+    parser.add_argument("--body", required=True, help="Message body")
+    parser.add_argument("--model", help="LLM model to use (overrides agent_config.json)")
+    parser.add_argument("--thread-depth", type=int, default=0, help="Current thread depth (for loop awareness)")
+    parser.add_argument("--max-depth", type=int, default=3, help="Maximum thread depth before stopping")
+
+    args = parser.parse_args()
+
+    # Run async function
+    result = asyncio.run(generate_response(
+        agent_name=args.agent_name,
+        from_name=args.from_name,
+        subject=args.subject,
+        body=args.body,
+        model=args.model,
+        thread_depth=args.thread_depth,
+        max_depth=args.max_depth
+    ))
+
+    # Output JSON
+    print(json.dumps(result, indent=2))
+
+    # Exit with error code if failed
+    if "error" in result:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_agent_mail/autopilot/__init__.py
+++ b/src/mcp_agent_mail/autopilot/__init__.py
@@ -1,0 +1,5 @@
+"""Autonomous orchestration helpers for daily executive sync."""
+
+from .daily_sync import main as daily_sync_main, run_daily_sync
+
+__all__ = ["run_daily_sync", "daily_sync_main"]

--- a/src/mcp_agent_mail/autopilot/daily_sync.py
+++ b/src/mcp_agent_mail/autopilot/daily_sync.py
@@ -1,0 +1,350 @@
+"""Daily 04:00 executive sync orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+
+from ..config import get_settings
+from ..db import ensure_schema, get_session
+from ..models import Agent, Project
+from .ledger import TaskRecord, bead_balances, fetch_open_tasks, get_agent_map, resolve_project
+
+
+DEFAULT_EXECUTIVES = ("GreenPresident", "WhiteFox", "BlackDog")
+DEFAULT_PROJECT_KEY = "/Users/nickflorez/Projects/win"
+AUTOPILOT_AGENT_NAME = "Autopilot"
+
+
+def _load_local_env() -> None:
+    """Load .env file if present for local execution."""
+
+    root = Path(__file__).resolve().parents[2]
+    env_path = root / ".env"
+    if not env_path.exists():
+        return
+
+    for raw_line in env_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
+@dataclass(slots=True)
+class AgentBrief:
+    agent: Agent
+    bead_balance: int
+    assigned: list[dict[str, Any]]
+    backlog: list[dict[str, Any]]
+    message_body: str
+    thread_id: str
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_thread_id(agent_name: str, run_id: str) -> str:
+    return f"daily-sync-{agent_name.lower()}-{run_id}"
+
+
+def _format_task_summary(task: dict[str, Any]) -> str:
+    due = task.get("due_ts")
+    due_str = "—" if not due else datetime.fromisoformat(due).strftime("%Y-%m-%d")
+    bead = task.get("bead_value", 0)
+    return f"- **#{task['id']}** · {task['title']} · Due: {due_str} · Beads: {bead}\n  {task['description'].strip() or '_No description_' }"
+
+
+def _render_brief(agent_name: str, bead_balance: int, assigned: list[dict[str, Any]], backlog: list[dict[str, Any]]) -> str:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    lines = [f"# Daily Sync Brief — {agent_name}", "", f"Date: {today}", f"Current Beads: {bead_balance}", ""]
+
+    lines.append("## Assigned Tasks")
+    if assigned:
+        for task in assigned:
+            lines.append(_format_task_summary(task))
+    else:
+        lines.append("- _No owned tasks currently_")
+
+    lines.append("")
+    lines.append("## Unassigned / Backlog Opportunities")
+    if backlog:
+        for task in backlog:
+            lines.append(_format_task_summary(task))
+    else:
+        lines.append("- _No open backlog items_")
+
+    lines.extend(
+        [
+            "",
+            "## Required Actions",
+            "1. Confirm ownership or reassign as needed",
+            "2. Provide bead adjustments in response using `BEAD_TXN` markers",
+            "3. Flag risks or dependencies blocking progress",
+            "",
+            "— Autopilot Orchestrator",
+        ]
+    )
+    return "\n".join(lines)
+
+
+async def _prepare_briefs(
+    *,
+    project: Project,
+    agent_names: Iterable[str],
+    run_id: str,
+    tasks: list[TaskRecord],
+) -> list[AgentBrief]:
+    agent_map = await get_agent_map(project.id, agent_names)
+    missing = [name for name in agent_names if name not in agent_map]
+    if missing:
+        raise RuntimeError(f"Agents not registered for project {project_key}: {', '.join(missing)}")
+
+    serialised = []
+    for record in tasks:
+        serialised.append(
+            {
+                "id": record.id,
+                "title": record.title,
+                "status": record.status,
+                "priority": record.priority,
+                "bead_value": record.bead_value,
+                "due_ts": record.due_ts.isoformat() if record.due_ts else None,
+                "owner": record.owner_agent,
+                "description": record.description,
+            }
+        )
+
+    balances = await bead_balances(agent.id for agent in agent_map.values())
+    briefs: list[AgentBrief] = []
+    for name, agent in agent_map.items():
+        assigned = [task for task in serialised if task.get("owner") == name]
+        backlog = [task for task in serialised if task.get("owner") is None]
+        message_body = _render_brief(
+            name,
+            balances.get(agent.id, 0),
+            assigned,
+            backlog,
+        )
+        briefs.append(
+            AgentBrief(
+                agent=agent,
+                bead_balance=balances.get(agent.id, 0),
+                assigned=assigned,
+                backlog=backlog,
+                message_body=message_body,
+                thread_id=_build_thread_id(name, run_id),
+            )
+        )
+    return briefs
+
+
+async def _ensure_autopilot_agent(project: Project) -> Agent:
+    """Ensure the scheduler agent exists in the roster."""
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(Agent).where(Agent.project_id == project.id, Agent.name == AUTOPILOT_AGENT_NAME)
+        )
+        agent = result.scalars().first()
+        if agent:
+            return agent
+
+        now = datetime.now(timezone.utc)
+        agent = Agent(
+            project_id=project.id,
+            name=AUTOPILOT_AGENT_NAME,
+            program="scheduler",
+            model="system",
+            task_description="Autonomous orchestrator for daily executive sync",
+            inception_ts=now,
+            last_active_ts=now,
+            attachments_policy="auto",
+            contact_policy="auto",
+        )
+        session.add(agent)
+        await session.commit()
+        await session.refresh(agent)
+        return agent
+
+
+_load_local_env()
+
+
+async def _send_messages(
+    *,
+    briefs: Iterable[AgentBrief],
+    project_key: str,
+    bearer_token: str,
+    sender_name: str,
+    dry_run: bool,
+    mcp_endpoint: str,
+) -> list[dict[str, Any]]:
+    headers = {"Authorization": f"Bearer {bearer_token}", "Content-Type": "application/json"}
+    results: list[dict[str, Any]] = []
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        for brief in briefs:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": int(datetime.now().timestamp() * 1000),
+                "method": "tools/call",
+                "params": {
+                    "name": "send_message",
+                    "arguments": {
+                        "project_key": project_key,
+                        "sender_name": sender_name,
+                        "to": [brief.agent.name],
+                        "subject": f"Daily Sync: {brief.agent.name}",
+                        "body_md": brief.message_body,
+                        "thread_id": brief.thread_id,
+                        "importance": "high",
+                    },
+                },
+            }
+            if dry_run:
+                results.append({"agent": brief.agent.name, "thread_id": brief.thread_id, "status": "dry-run"})
+                continue
+
+            response = await client.post(mcp_endpoint, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            results.append({"agent": brief.agent.name, "thread_id": brief.thread_id, "response": data})
+    return results
+
+
+async def run_daily_sync(
+    *,
+    project_key: str = DEFAULT_PROJECT_KEY,
+    agent_names: Iterable[str] = DEFAULT_EXECUTIVES,
+    dry_run: bool = False,
+    wait_seconds: int = 0,
+    run_id: str | None = None,
+    bearer_token: str | None = None,
+    mcp_endpoint: str | None = None,
+    task_limit: int = 25,
+) -> dict[str, Any]:
+    """Execute daily sync orchestration."""
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url or not db_url.startswith("sqlite+"):
+        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///messages.db"
+
+    await ensure_schema(get_settings())
+    resolved_run_id = run_id or datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+    project = await resolve_project(project_key)
+    autopilot_agent = await _ensure_autopilot_agent(project)
+    task_records = await fetch_open_tasks(project.id, limit=task_limit)
+    briefs = await _prepare_briefs(project=project, agent_names=agent_names, run_id=resolved_run_id, tasks=task_records)
+
+    token = bearer_token or os.environ.get("HTTP_BEARER_TOKEN") or os.environ.get("MCP_BEARER_TOKEN")
+    if not token and not dry_run:
+        raise RuntimeError("HTTP bearer token must be provided via --bearer-token or environment")
+
+    endpoint = mcp_endpoint or os.environ.get("MCP_ENDPOINT", "http://127.0.0.1:8765/mcp/")
+    send_results = await _send_messages(
+        briefs=briefs,
+        project_key=project_key,
+        bearer_token=token or "",
+        sender_name=autopilot_agent.name,
+        dry_run=dry_run,
+        mcp_endpoint=endpoint,
+    )
+
+    run_summary = {
+        "run_id": resolved_run_id,
+        "timestamp": _iso_now(),
+        "project_key": project_key,
+        "dry_run": dry_run,
+        "wait_seconds": wait_seconds,
+        "task_limit": task_limit,
+        "agents": [
+            {
+                "agent": brief.agent.name,
+                "beads": brief.bead_balance,
+                "assigned": brief.assigned,
+                "backlog": brief.backlog,
+                "thread_id": brief.thread_id,
+            }
+            for brief in briefs
+        ],
+        "send_results": send_results,
+    }
+
+    _write_run_log(run_summary)
+
+    if wait_seconds > 0 and not dry_run:
+        await asyncio.sleep(wait_seconds)
+        # Response harvesting would be implemented here in future iterations.
+
+    return run_summary
+
+
+def _write_run_log(summary: dict[str, Any]) -> None:
+    logs_root = Path("logs/autopilot")
+    logs_root.mkdir(parents=True, exist_ok=True)
+    filename = logs_root / f"daily_sync_{summary['run_id']}.json"
+    with filename.open("w", encoding="utf-8") as fp:
+        json.dump(summary, fp, indent=2)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the 04:00 executive sync pilot.")
+    parser.add_argument("--project-key", default=DEFAULT_PROJECT_KEY, help="Project human key/slug to target")
+    parser.add_argument(
+        "--agents",
+        nargs="*",
+        default=list(DEFAULT_EXECUTIVES),
+        help="Agent names to receive the briefing",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Skip sending messages and just log output")
+    parser.add_argument("--wait-seconds", type=int, default=0, help="Optional wait period to harvest responses later")
+    parser.add_argument("--run-id", help="Explicit run identifier (defaults to timestamp)")
+    parser.add_argument("--bearer-token", help="HTTP bearer token override")
+    parser.add_argument("--endpoint", help="MCP endpoint override (default http://127.0.0.1:8765/mcp/)")
+    parser.add_argument("--task-limit", type=int, default=25, help="Maximum tasks to load from ledger (default 25)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        summary = asyncio.run(
+            run_daily_sync(
+                project_key=args.project_key,
+                agent_names=args.agents,
+                dry_run=args.dry_run,
+                wait_seconds=args.wait_seconds,
+                run_id=args.run_id,
+                bearer_token=args.bearer_token,
+                mcp_endpoint=args.endpoint,
+                task_limit=args.task_limit,
+            )
+        )
+    except NoResultFound as exc:
+        parser.error(str(exc))
+        return
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry
+    main()

--- a/src/mcp_agent_mail/autopilot/ledger.py
+++ b/src/mcp_agent_mail/autopilot/ledger.py
@@ -1,0 +1,188 @@
+"""Database helpers for task and bead ledger management."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import NoResultFound
+
+from ..db import get_session
+from ..models import Agent, BeadTransaction, Project, Task
+from ..utils import slugify
+
+
+BEADS_DB_DEFAULT = Path(__file__).resolve().parents[4] / ".beads" / "beads.db"
+
+
+@dataclass(slots=True)
+class TaskRecord:
+    id: str
+    title: str
+    status: str
+    priority: str
+    bead_value: int
+    due_ts: Optional[datetime]
+    owner_agent: Optional[str]
+    description: str
+
+
+async def resolve_project(project_key: str) -> Project:
+    """Return project row for given human key or slug."""
+
+    slug = slugify(project_key)
+    async with get_session() as session:
+        result = await session.execute(
+            select(Project).where((Project.slug == slug) | (Project.human_key == project_key))
+        )
+        project = result.scalars().first()
+        if not project:
+            raise NoResultFound(f"Project not found for key: {project_key}")
+        return project
+
+
+async def fetch_open_tasks(project_id: int, *, limit: int = 100) -> list[TaskRecord]:
+    """Return open or in-progress tasks sourced from internal table or Beads DB."""
+
+    sqlmodel_tasks = await _fetch_sqlmodel_tasks(project_id, limit)
+    if sqlmodel_tasks:
+        return sqlmodel_tasks
+    return _fetch_beads_tasks(limit)
+
+
+async def _fetch_sqlmodel_tasks(project_id: int, limit: int) -> list[TaskRecord]:
+    async with get_session() as session:
+        result = await session.execute(
+            select(Task, Agent.name)
+            .outerjoin(Agent, Agent.id == Task.owner_agent_id)
+            .where(Task.project_id == project_id, Task.status.in_(("open", "in_progress")))
+            .order_by(Task.priority.desc(), Task.due_ts.is_(None), Task.due_ts.asc(), Task.created_ts.asc())
+            .limit(limit)
+        )
+
+        records: list[TaskRecord] = []
+        for task, owner_name in result.all():
+            records.append(
+                TaskRecord(
+                    id=str(task.id),
+                    title=task.title,
+                    status=task.status,
+                    priority=task.priority,
+                    bead_value=task.bead_value,
+                    due_ts=task.due_ts,
+                    owner_agent=owner_name,
+                    description=task.description or "",
+                )
+            )
+        return records
+
+
+def _resolve_beads_path() -> Optional[Path]:
+    path = os.environ.get("BEADS_DB_PATH")
+    if path:
+        candidate = Path(path).expanduser()
+        if candidate.exists():
+            return candidate
+    if BEADS_DB_DEFAULT.exists():
+        return BEADS_DB_DEFAULT
+    return None
+
+
+def _fetch_beads_tasks(limit: int) -> list[TaskRecord]:
+    beads_path = _resolve_beads_path()
+    if not beads_path:
+        return []
+
+    conn = sqlite3.connect(str(beads_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, title, status, priority, assignee, description, acceptance_criteria, notes, created_at
+            FROM issues
+            WHERE status = 'open'
+            ORDER BY priority DESC, created_at ASC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    records: list[TaskRecord] = []
+    for row in rows:
+        notes_parts = [row["description"], row["acceptance_criteria"], row["notes"]]
+        description = "\n\n".join(part.strip() for part in notes_parts if part and part.strip())
+        bead_value = int(row["priority"] or 0)
+        records.append(
+            TaskRecord(
+                id=row["id"],
+                title=row["title"],
+                status=row["status"],
+                priority=str(row["priority"] or ""),
+                bead_value=bead_value,
+                due_ts=None,
+                owner_agent=row["assignee"] or None,
+                description=description,
+            )
+        )
+    return records
+
+
+async def get_agent_map(project_id: int, agent_names: Iterable[str]) -> dict[str, Agent]:
+    """Return mapping of agent name -> Agent row for project."""
+
+    names = {name for name in agent_names}
+    if not names:
+        return {}
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(Agent).where(Agent.project_id == project_id, Agent.name.in_(names))
+        )
+        agents = {agent.name: agent for agent in result.scalars()}
+        return agents
+
+
+async def bead_balances(agent_ids: Iterable[int]) -> dict[int, int]:
+    """Compute current bead balance per agent id."""
+
+    ids = list(agent_ids)
+    if not ids:
+        return {}
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(BeadTransaction.agent_id, func.coalesce(func.sum(BeadTransaction.delta), 0))
+            .where(BeadTransaction.agent_id.in_(ids))
+            .group_by(BeadTransaction.agent_id)
+        )
+        return {row[0]: int(row[1]) for row in result.all()}
+
+
+async def record_bead_transaction(
+    *,
+    agent_id: int,
+    delta: int,
+    reason: str,
+    task_id: Optional[int],
+    run_id: Optional[str],
+) -> None:
+    """Append a bead ledger entry."""
+
+    async with get_session() as session:
+        txn = BeadTransaction(
+            agent_id=agent_id,
+            task_id=task_id,
+            delta=delta,
+            reason=reason,
+            run_id=run_id,
+        )
+        session.add(txn)
+        await session.commit()

--- a/src/mcp_agent_mail/models.py
+++ b/src/mcp_agent_mail/models.py
@@ -114,3 +114,52 @@ class ProjectSiblingSuggestion(SQLModel, table=True):
     evaluated_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     confirmed_ts: Optional[datetime] = Field(default=None)
     dismissed_ts: Optional[datetime] = Field(default=None)
+
+
+class Task(SQLModel, table=True):
+    """High-level work item tracked for autonomous coordination."""
+
+    __tablename__ = "tasks"
+    __table_args__ = (UniqueConstraint("project_id", "external_id", name="uq_task_external"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="projects.id", index=True)
+    external_id: Optional[str] = Field(default=None, max_length=128)
+    title: str = Field(max_length=512)
+    description: str = Field(default="", max_length=8192)
+    status: str = Field(default="open", max_length=32)
+    priority: str = Field(default="normal", max_length=16)
+    bead_value: int = Field(default=0)
+    due_ts: Optional[datetime] = None
+    owner_agent_id: Optional[int] = Field(default=None, foreign_key="agents.id")
+    created_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class TaskAssignment(SQLModel, table=True):
+    """History of agent-task interactions and commitments."""
+
+    __tablename__ = "task_assignments"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    task_id: int = Field(foreign_key="tasks.id", index=True)
+    agent_id: int = Field(foreign_key="agents.id", index=True)
+    status: str = Field(default="proposed", max_length=32)
+    bead_stake: int = Field(default=0)
+    notes: str = Field(default="", max_length=4096)
+    created_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class BeadTransaction(SQLModel, table=True):
+    """Ledger of incentive adjustments for agents."""
+
+    __tablename__ = "beads_transactions"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    agent_id: int = Field(foreign_key="agents.id", index=True)
+    task_id: Optional[int] = Field(default=None, foreign_key="tasks.id", index=True)
+    delta: int = Field()
+    reason: str = Field(default="", max_length=512)
+    run_id: Optional[str] = Field(default=None, max_length=64)
+    created_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary
- add an autonomous 04:00 executive sync orchestrator that briefs core agents
- integrate bead ledger tasks from `.beads/beads.db` when internal tables are empty
- provide a generate_response helper with updated prompts for structured daily sync replies

## Changes
- add `autopilot` package with daily sync runner, logging, and autopilot agent bootstrap
- implement ledger helpers to source tasks and bead balances from SQLModel tables or the Beads workspace
- ship a CLI generator for agent responses reflecting the new daily sync protocol sections

## Testing
- pnpm -C web lint:fix
- pnpm -C web typecheck *(fails: pre-existing TS2367 comparisons in `basketball-scorekeeping-supabase.ts`)*
- pnpm -C web build *(fails: same pre-existing TS2367 issue)*
- python -m mcp_agent_mail.autopilot.daily_sync --dry-run
- python -m mcp_agent_mail.autopilot.daily_sync --dry-run --task-limit 20

🤖 Generated with Droid
