### PR TITLE
fix(install): use current directory as default target instead of script root

### DIFF
--- a/scripts/integrate_claude_code.sh
+++ b/scripts/integrate_claude_code.sh
@@ -25,7 +25,7 @@ echo "  3) Auto-generate a bearer token if missing and embed it in the client co
 echo "  4) Create scripts/run_server_with_token.sh that exports the token and starts the server."
 echo
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_cline.sh
+++ b/scripts/integrate_cline.sh
@@ -27,7 +27,7 @@ echo "  5) Attempt a readiness check and bootstrap ensure_project/register_agent
 echo
 
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_codex_cli.sh
+++ b/scripts/integrate_codex_cli.sh
@@ -25,7 +25,7 @@ echo "  3) Generate a project-local codex.mcp.json (auto-backup existing)."
 echo "  4) Create scripts/run_server_with_token.sh to start the server with the token."
 echo
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_cursor.sh
+++ b/scripts/integrate_cursor.sh
@@ -25,7 +25,7 @@ echo "  3) Produce a cursor.mcp.json (auto-backup existing)."
 echo "  4) Create scripts/run_server_with_token.sh to start the server with the token."
 echo
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_gemini_cli.sh
+++ b/scripts/integrate_gemini_cli.sh
@@ -25,7 +25,7 @@ echo "  3) Generate gemini.mcp.json (auto-backup existing)."
 echo "  4) Create scripts/run_server_with_token.sh to start the server with the token."
 echo
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_github_copilot.sh
+++ b/scripts/integrate_github_copilot.sh
@@ -30,7 +30,7 @@ echo "  4) Optionally enable MCP discovery in user settings (if VS Code installe
 echo "  5) Create run helper script and bootstrap project/agent registration."
 echo
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_opencode.sh
+++ b/scripts/integrate_opencode.sh
@@ -29,7 +29,7 @@ echo "  5) Create run helper script and bootstrap project/agent registration."
 echo
 
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"

--- a/scripts/integrate_windsurf.sh
+++ b/scripts/integrate_windsurf.sh
@@ -27,7 +27,7 @@ echo "  5) Attempt a readiness check and bootstrap ensure_project/register_agent
 echo
 
 TARGET_DIR="${PROJECT_DIR:-}"
-if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
 if ! confirm "Proceed?"; then log_warn "Aborted."; exit 1; fi
 
 cd "$ROOT_DIR"


### PR DESCRIPTION
## Summary
When running the integration scripts (like `integrate_claude_code.sh`) from a project root where the scripts reside in a subdirectory (e.g. `mcp_agent_mail/scripts/`), the default `TARGET_DIR` was incorrectly resolving to the script's parent directory (`mcp_agent_mail/`) instead of the user's current working directory.

This caused configuration files like `.claude/settings.json` to be created inside the `mcp_agent_mail` subdirectory instead of the project root, effectively failing to install the hooks/configuration where the user expected.

## Fix
Changed the default `TARGET_DIR` logic to use `$(pwd)` (current working directory) when no `PROJECT_DIR` is specified.

```bash
- if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="${ROOT_DIR}"; fi
+ if [[ -z "${TARGET_DIR}" ]]; then TARGET_DIR="$(pwd)"; fi
```

## Testing
- Verified locally that running the script now correctly targets the project root when executed from the root, even if the script file is in a subdirectory.