### PR TITLE
feat: add serve-stdio command to CLI

### DIFF
--- a/src/mcp_agent_mail/cli.py
+++ b/src/mcp_agent_mail/cli.py
@@ -599,6 +599,15 @@ def serve_http(
     uvicorn.run(app, **_kwargs)
 
 
+@app.command("serve-stdio")
+def serve_stdio() -> None:
+    """Run the MCP server over stdio (standard input/output)."""
+    # Important: Do not print anything to stdout (banners, logs) before
+    # or during the server run, as it corrupts the JSON-RPC transport.
+    server = build_mcp_server()
+    server.run(transport="stdio")
+
+
 def _run_command(command: list[str]) -> None:
     console.print(f"[cyan]$ {' '.join(command)}[/]")
     result = subprocess.run(command, check=False)


### PR DESCRIPTION
## Summary
Adds a `serve-stdio` command to the CLI. This allows running the MCP server over standard input/output, which is the preferred transport method for local Claude Code integration (managed by the client) and avoids port conflicts or the need for a separate process management script.

## Usage
```bash
python -m mcp_agent_mail.cli serve-stdio
# or with uv tool if installed globally
uv tool run --from mcp-agent-mail python -m mcp_agent_mail.cli serve-stdio
```

## Context
This enables `type: "stdio"` configuration in `.mcp.json` or global settings, allowing for zero-config startup and faster interaction loops compared to HTTP.