### PR TITLE
fix(ui): update broken CDN links and script loading order

### DIFF
--- a/src/mcp_agent_mail/templates/base.html
+++ b/src/mcp_agent_mail/templates/base.html
@@ -164,7 +164,7 @@
     <script src="https://cdn.jsdelivr.net/npm/countup@1.8.2/dist/countUp.min.js"></script>
 
     <!-- Mo.js for micro-animations -->
-    <script src="https://cdn.jsdelivr.net/npm/@mojs/core@1.4.1/build/mo.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@mojs/core@1.7.1/dist/mo.umd.js"></script>
 
     <!-- Splitting.js for advanced text animations -->
     <script src="https://unpkg.com/splitting@1.0.6/dist/splitting.min.js"></script>
@@ -203,8 +203,8 @@
     <script src="https://cdn.jsdelivr.net/npm/diff2html@3.4.47/bundles/js/diff2html-ui.min.js"></script>
 
     <!-- Vis.js for network graphs -->
-    <script src="https://unpkg.com/vis-network@9.1.9/dist/vis-network.min.js"></script>
-    <link href="https://unpkg.com/vis-network@9.1.9/dist/vis-network.min.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+    <link href="https://unpkg.com/vis-network/styles/vis-network.min.css" rel="stylesheet" type="text/css" />
 
     <style>
       [x-cloak] { display: none !important; }


### PR DESCRIPTION
## Summary
Fixes `404 Not Found` and `MIME type mismatch` errors for `mo.js` and `vis-network` CDN assets in the web UI. Also fixes a `document.body is null` error caused by `mo.js` initializing too early.

## Changes
1.  Updated `@mojs/core` from `1.4.1/build/mo.min.js` (404) to `1.7.1/dist/mo.umd.js` (valid).
2.  Added `defer` attribute to `mo.js` script tag to prevent execution before `<body>` exists.
3.  Updated `vis-network` from `9.1.9/dist/vis-network.min.css` (404) to `styles/vis-network.min.css` (valid).
4.  Updated `vis-network` JS from `9.1.9/dist/vis-network.min.js` to `standalone/umd/vis-network.min.js` (valid).

## Testing
Verified that the web interface loads without console errors and animations/graphs render correctly.