### PR TITLE
Add tool tag filtering to reduce context token usage

### DIFF
--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -173,6 +173,14 @@ class Settings:
     messaging_auto_register_recipients: bool
     # When true, attempt a contact handshake automatically if delivery is blocked
     messaging_auto_handshake_on_block: bool
+    # Tool filtering (FastMCP tag-based filtering)
+    # Comma-separated list of tags to include (empty = all tags)
+    # Available tags match cluster names: infrastructure, identity, messaging,
+    # contact, search, file_reservations, workflow_macros, build_slots, product_bus
+    # Plus: "core" (essential tools for basic TDD workflows)
+    tool_include_tags: list[str]
+    # Comma-separated list of tags to exclude (takes precedence over include)
+    tool_exclude_tags: list[str]
 
 
 def _bool(value: str, *, default: bool) -> bool:
@@ -332,6 +340,8 @@ def get_settings() -> Settings:
         agent_name_enforcement_mode=_agent_name_mode(_decouple_config("AGENT_NAME_ENFORCEMENT_MODE", default="coerce")),
         messaging_auto_register_recipients=_bool(_decouple_config("MESSAGING_AUTO_REGISTER_RECIPIENTS", default="true"), default=True),
         messaging_auto_handshake_on_block=_bool(_decouple_config("MESSAGING_AUTO_HANDSHAKE_ON_BLOCK", default="true"), default=True),
+        tool_include_tags=_csv("TOOL_INCLUDE_TAGS", default=""),
+        tool_exclude_tags=_csv("TOOL_EXCLUDE_TAGS", default=""),
     )
 
 


### PR DESCRIPTION
## Summary

This PR adds FastMCP tag-based tool filtering to mcp-agent-mail, allowing users to significantly reduce context token usage by only loading the tools they need.

- Added tags to all `@mcp.tool()` decorators matching their cluster names
- Added a special `core` tag for essential TDD workflows
- Added `TOOL_INCLUDE_TAGS` and `TOOL_EXCLUDE_TAGS` environment variables

## Motivation

MCP tool definitions consume ~24.7k tokens in the context window before any actual work begins. For users who only need basic TDD workflows, this is a significant overhead.

With this change, users can filter to just `core` tools (~8 tools instead of 26+), reducing token usage by approximately 70%.

## Usage

```bash
# Only load core tools
TOOL_INCLUDE_TAGS=core python -m mcp_agent_mail

# Load core + specific clusters
TOOL_INCLUDE_TAGS=core,messaging,file_reservations python -m mcp_agent_mail

# Exclude advanced features
TOOL_EXCLUDE_TAGS=product_bus,build_slots,workflow_macros python -m mcp_agent_mail
```

## Available Tags

| Tag | Tools | Description |
|-----|-------|-------------|
| `core` | 7 | Essential TDD tools (ensure_project, register_agent, send/reply_message, fetch_inbox, file_reservation_paths, release_file_reservations) |
| `infrastructure` | 3 | Setup/config tools |
| `identity` | 3 | Agent identity management |
| `messaging` | 6 | Message sending/receiving |
| `contact` | 4 | Contact management |
| `search` | 2 | Search and summarization |
| `file_reservations` | 4 | File locking/reservation |
| `workflow_macros` | 4 | Convenience macros |
| `build_slots` | 3 | Build slot management |
| `product_bus` | 5 | Product bus features |

## Test plan

- [x] Python syntax validation passes
- [ ] Manual testing with `TOOL_INCLUDE_TAGS=core`
- [ ] Verify filtered tools appear correctly in MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)