### PR TITLE
Fix TypeError when comparing naive and aware datetimes in CLI

### DIFF
--- a/src/mcp_agent_mail/cli.py
+++ b/src/mcp_agent_mail/cli.py
@@ -3367,6 +3367,9 @@ def file_reservations_active(
     now = datetime.now(timezone.utc)
 
     def _fmt_delta(dt: datetime) -> str:
+        # Ensure dt is timezone-aware (assume UTC if naive)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
         delta = dt - now
         total = int(delta.total_seconds())
         sign = "-" if total < 0 else ""
@@ -3440,6 +3443,9 @@ def file_reservations_soon(
     table.add_column("In")
 
     def _fmt_delta(dt: datetime) -> str:
+        # Ensure dt is timezone-aware (assume UTC if naive)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
         delta = dt - now
         total = int(delta.total_seconds())
         sign = "-" if total < 0 else ""


### PR DESCRIPTION
## Summary
- Fix `TypeError: can't subtract offset-naive and offset-aware datetimes` in CLI commands

## Problem
The `_fmt_delta` function in `file_reservations active` and `file_reservations soon` commands crashes because:
- `now = datetime.now(timezone.utc)` is timezone-aware
- `file_reservation.expires_ts` from the database is timezone-naive
- Python doesn't allow subtracting these

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

## Solution
Ensure `dt` is timezone-aware before subtraction by assuming naive datetimes are UTC:

```python
def _fmt_delta(dt: datetime) -> str:
    if dt.tzinfo is None:
        dt = dt.replace(tzinfo=timezone.utc)
    delta = dt - now
    ...
```

## Test plan
```bash
# Reserve a file
uv run python -m mcp_agent_mail.cli file_reservations active /path/to/project
# Previously crashed, now shows table correctly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)