### PR TITLE
Fix incorrect MCP endpoint URL in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-agent-mail": {
       "type": "http",
-      "url": "http://127.0.0.1:8765/mcp/",
+      "url": "http://127.0.0.1:8765/api/",
       "headers": {
         "Authorization": "Bearer ee9102dcfc58d84b96a22113ac32fbcc757bf0b7e167e97b6d3a3495d1b758cd"
       }


### PR DESCRIPTION
## Summary
- Fixes incorrect MCP endpoint path in `.mcp.json` config file
- Changes `/mcp/` to `/api/` to match the actual server mount path defined in `http.py` (line 1101)

## Problem
The `.mcp.json` file specified `/mcp/` as the endpoint URL, but the HTTP server actually mounts the MCP endpoint at `/api/` by default:

```python
# http.py line 1101
mount_base = settings.http.path or "/api"
```

This mismatch prevents MCP clients configured via `.mcp.json` from successfully connecting to the server.

## Test plan
- [ ] Start the MCP server with default settings
- [ ] Verify clients using `.mcp.json` can connect to the `/api/` endpoint

---

Generated with [Claude Code](https://claude.com/claude-code)