### PR TITLE
fix(scripts): replace hardcoded author paths with $HOME for portability

### DIFF
--- a/scripts/run_server_with_token.sh
+++ b/scripts/run_server_with_token.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AM_RUST_BIN="/Users/jemanuel/.local/bin/am"
-AM_RUST_ENV_FILE_DEFAULT="/Users/jemanuel/.config/mcp-agent-mail/config.env"
+AM_RUST_BIN="${HOME}/.local/bin/am"
+AM_RUST_ENV_FILE_DEFAULT="${HOME}/.config/mcp-agent-mail/config.env"
 AM_RUST_ENV_FILE="${AM_RUST_ENV_FILE:-$AM_RUST_ENV_FILE_DEFAULT}"
 if [ ! -f "$AM_RUST_ENV_FILE" ] && [ -f "${HOME}/.config/mcp-agent-mail/config.env" ]; then
   AM_RUST_ENV_FILE="${HOME}/.config/mcp-agent-mail/config.env"


### PR DESCRIPTION
## Summary

`scripts/run_server_with_token.sh` has the upstream author's personal home directory (`/Users/jemanuel/`) hardcoded on lines 4-5 for `AM_RUST_BIN` and `AM_RUST_ENV_FILE_DEFAULT`. This breaks the script for every other user.

This PR replaces both occurrences with `${HOME}` so the paths resolve correctly on any machine.

## Changes

- `AM_RUST_BIN`: `/Users/jemanuel/.local/bin/am` → `${HOME}/.local/bin/am`
- `AM_RUST_ENV_FILE_DEFAULT`: `/Users/jemanuel/.config/mcp-agent-mail/config.env` → `${HOME}/.config/mcp-agent-mail/config.env`

These were the only two instances of hardcoded author paths in the repository (confirmed via grep).