### PR TITLE
[codex] fix integration runtime token resolution

### DIFF
--- a/scripts/integrate_claude_code.sh
+++ b/scripts/integrate_claude_code.sh
@@ -52,22 +52,9 @@ log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 # Determine or generate bearer token (prefer session token provided by orchestrator)
 # Reuse existing token if possible (INTEGRATION_BEARER_TOKEN > .env > run helper)
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
-if [[ -z "${_TOKEN}" && -f scripts/run_server_with_token.sh ]]; then
-  _TOKEN=$(grep -E 'export HTTP_BEARER_TOKEN="' scripts/run_server_with_token.sh | sed -E 's/.*HTTP_BEARER_TOKEN="([^"]+)".*/\1/') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -382,30 +369,7 @@ set_secure_file "$HOME_SETTINGS_PATH" || true
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER"
+write_run_helper_script "$RUN_HELPER"
 echo "Created $RUN_HELPER"
 
 # Register with Claude Code CLI at user and project scope for immediate discovery

--- a/scripts/integrate_cline.sh
+++ b/scripts/integrate_cline.sh
@@ -52,19 +52,9 @@ _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
 log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 # Determine or generate bearer token
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -95,30 +85,7 @@ set_secure_file "$OUT_JSON" || true
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER" || true
+write_run_helper_script "$RUN_HELPER"
 
 # Readiness check (bounded)
 log_step "Attempt readiness check (bounded)"
@@ -168,5 +135,4 @@ else
   _print "  - Header: (optional on localhost if server allows)"
 fi
 _print "Then start the server with: ${RUN_HELPER}"
-
 

--- a/scripts/integrate_codex_cli.sh
+++ b/scripts/integrate_codex_cli.sh
@@ -52,16 +52,12 @@ _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
 log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 _TOKEN_GENERATED=0
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-${_HTTP_BEARER_TOKEN:-}}"
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
+if [[ -z "${_TOKEN}" && -n "${_HTTP_BEARER_TOKEN:-}" ]]; then
+  _TOKEN="${_HTTP_BEARER_TOKEN}"
+fi
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   _TOKEN_GENERATED=1
   log_ok "Generated bearer token."
 fi
@@ -123,30 +119,7 @@ set_secure_file "$OUT_JSON"
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER"
+write_run_helper_script "$RUN_HELPER"
 
 log_step "Checking server and registering agent"
 _AGENT=""

--- a/scripts/integrate_cursor.sh
+++ b/scripts/integrate_cursor.sh
@@ -46,19 +46,9 @@ if [[ -z "${_HTTP_HOST}" || -z "${_HTTP_PORT}" || -z "${_HTTP_PATH}" ]]; then
 fi
 
 _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   echo "Generated bearer token."
 fi
 AUTH_HEADER_LINE="        \"Authorization\": \"Bearer ${_TOKEN}\""
@@ -81,30 +71,7 @@ set_secure_file "$OUT_JSON"
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER"
+write_run_helper_script "$RUN_HELPER"
 
 echo "Wrote ${OUT_JSON}. Configure in Cursor if/when MCP settings are supported."
 echo "Server start: $RUN_HELPER"
@@ -118,7 +85,22 @@ if [[ -f "$HOME_CURSOR_JSON" ]]; then
   backup_file "$HOME_CURSOR_JSON"
 fi
 
-write_atomic "$HOME_CURSOR_JSON" <<JSON
+if [[ -n "${_TOKEN}" ]]; then
+  write_atomic "$HOME_CURSOR_JSON" <<JSON
+{
+  "mcpServers": {
+    "mcp-agent-mail": {
+      "type": "http",
+      "url": "${_URL}",
+      "headers": {
+        "Authorization": "Bearer ${_TOKEN}"
+      }
+    }
+  }
+}
+JSON
+else
+  write_atomic "$HOME_CURSOR_JSON" <<JSON
 {
   "mcpServers": {
     "mcp-agent-mail": {
@@ -128,6 +110,7 @@ write_atomic "$HOME_CURSOR_JSON" <<JSON
   }
 }
 JSON
+fi
 
 # Bug 1 fix: Ensure secure permissions
 # Bug #5 fix: set_secure_file logs its own warning, no need to duplicate
@@ -169,4 +152,3 @@ else
     log_warn "Failed to register agent (server may be starting)"
   fi
 fi
-

--- a/scripts/integrate_factory_droid.sh
+++ b/scripts/integrate_factory_droid.sh
@@ -46,19 +46,9 @@ if [[ -z "${_HTTP_HOST}" || -z "${_HTTP_PORT}" || -z "${_HTTP_PATH}" ]]; then
 fi
 
 _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -87,30 +77,7 @@ log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
 if [[ ! -f "$RUN_HELPER" ]]; then
-  write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-  set_secure_exec "$RUN_HELPER"
+  write_run_helper_script "$RUN_HELPER"
 fi
 
 echo "Wrote ${OUT_JSON}."
@@ -125,7 +92,21 @@ if [[ -f "$HOME_FACTORY_JSON" ]]; then
 fi
 
 # Factory Droid uses "url" for HTTP transport
-write_atomic "$HOME_FACTORY_JSON" <<JSON
+if [[ -n "${_TOKEN}" ]]; then
+  write_atomic "$HOME_FACTORY_JSON" <<JSON
+{
+  "mcpServers": {
+    "mcp-agent-mail": {
+      "url": "${_URL}",
+      "headers": {
+        "Authorization": "Bearer ${_TOKEN}"
+      }
+    }
+  }
+}
+JSON
+else
+  write_atomic "$HOME_FACTORY_JSON" <<JSON
 {
   "mcpServers": {
     "mcp-agent-mail": {
@@ -134,6 +115,7 @@ write_atomic "$HOME_FACTORY_JSON" <<JSON
   }
 }
 JSON
+fi
 
 set_secure_file "$HOME_FACTORY_JSON" || true
 log_step "Attempt readiness check (bounded)"

--- a/scripts/integrate_gemini_cli.sh
+++ b/scripts/integrate_gemini_cli.sh
@@ -46,19 +46,9 @@ if [[ -z "${_HTTP_HOST}" || -z "${_HTTP_PORT}" || -z "${_HTTP_PATH}" ]]; then
 fi
 
 _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -109,30 +99,7 @@ set_secure_file "$OUT_JSON"
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER"
+write_run_helper_script "$RUN_HELPER"
 
 echo "Wrote ${OUT_JSON}. Some Gemini CLIs may not yet support MCP; keep for reference."
 echo "Server start: $RUN_HELPER"
@@ -147,12 +114,15 @@ if [[ -f "$HOME_GEMINI_JSON" ]]; then
 fi
 
 # Gemini CLI uses "httpUrl" for Streamable HTTP transport
+if [[ -n "${_TOKEN}" ]]; then
+  _HOME_MCP_SERVER_JSON='"mcp-agent-mail": {"httpUrl": "'"${_URL}"'", "headers": {"Authorization": "Bearer '"${_TOKEN}"'"}}'
+else
+  _HOME_MCP_SERVER_JSON='"mcp-agent-mail": {"httpUrl": "'"${_URL}"'"}'
+fi
 write_atomic "$HOME_GEMINI_JSON" <<JSON
 {
   "mcpServers": {
-    "mcp-agent-mail": {
-      "httpUrl": "${_URL}"
-    }$(if [[ -n "${_MORPH_API_KEY}" ]]; then cat <<JSONFRAG
+    ${_HOME_MCP_SERVER_JSON}$(if [[ -n "${_MORPH_API_KEY}" ]]; then cat <<JSONFRAG
 ,
     "morph-mcp": {
       "command": "npx",

--- a/scripts/integrate_github_copilot.sh
+++ b/scripts/integrate_github_copilot.sh
@@ -57,19 +57,9 @@ _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
 log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 # Determine or generate bearer token
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -183,30 +173,7 @@ fi
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER" || true
+write_run_helper_script "$RUN_HELPER"
 
 # Readiness check (bounded)
 log_step "Attempt readiness check (bounded)"
@@ -262,4 +229,3 @@ _print "  - URL: ${_URL}"
 _print "  - Header: Authorization: Bearer <token>"
 _print ""
 _print "Documentation: https://code.visualstudio.com/docs/copilot/customization/mcp-servers"
-

--- a/scripts/integrate_opencode.sh
+++ b/scripts/integrate_opencode.sh
@@ -55,19 +55,9 @@ _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
 log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 # Determine or generate bearer token
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -152,30 +142,7 @@ fi
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER" || true
+write_run_helper_script "$RUN_HELPER"
 
 # Readiness check (bounded)
 log_step "Attempt readiness check (bounded)"
@@ -223,5 +190,4 @@ _print "The MCP tools will be available to the AI agent alongside built-in tools
 _print ""
 _print "Start the server with: ${RUN_HELPER}"
 _print "Then launch OpenCode in this directory."
-
 

--- a/scripts/integrate_windsurf.sh
+++ b/scripts/integrate_windsurf.sh
@@ -52,19 +52,9 @@ _URL="http://${_HTTP_HOST}:${_HTTP_PORT}${_HTTP_PATH}"
 log_ok "Detected MCP HTTP endpoint: ${_URL}"
 
 # Determine or generate bearer token
-_TOKEN="${INTEGRATION_BEARER_TOKEN:-}"
-if [[ -z "${_TOKEN}" && -f .env ]]; then
-  _TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-fi
+_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 if [[ -z "${_TOKEN}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
-    _TOKEN=$(openssl rand -hex 32)
-  else
-    _TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  fi
+  _TOKEN="$(generate_bearer_token)"
   log_ok "Generated bearer token."
 fi
 
@@ -95,30 +85,7 @@ set_secure_file "$OUT_JSON" || true
 log_step "Creating run helper script"
 mkdir -p scripts
 RUN_HELPER="scripts/run_server_with_token.sh"
-write_atomic "$RUN_HELPER" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if [[ -f .env ]]; then
-    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' .env | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
-  fi
-fi
-if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
-  if command -v uv >/dev/null 2>&1; then
-    HTTP_BEARER_TOKEN=$(uv run python - <<'PY'
-import secrets; print(secrets.token_hex(32))
-PY
-)
-  else
-    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname)"
-  fi
-fi
-export HTTP_BEARER_TOKEN
-
-uv run python -m mcp_agent_mail.cli serve-http "$@"
-SH
-set_secure_exec "$RUN_HELPER" || true
+write_run_helper_script "$RUN_HELPER"
 
 # Readiness check (bounded)
 log_step "Attempt readiness check (bounded)"
@@ -168,5 +135,4 @@ else
   _print "  - Header: (optional on localhost if server allows)"
 fi
 _print "Then start the server with: ${RUN_HELPER}"
-
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -69,6 +69,74 @@ require_cmd() {
   command -v "$cmd" >/dev/null 2>&1 || { log_err "Missing dependency: $cmd"; exit 1; }
 }
 
+# Read a simple KEY=value pair from an env file.
+read_env_file_value() {
+  local file="$1"
+  local key="$2"
+  [[ -f "$file" ]] || return 1
+  grep -E "^${key}=" "$file" | tail -n 1 | sed -E "s/^${key}=//"
+}
+
+# Generate a bearer token for local integrations.
+generate_bearer_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  elif command -v python >/dev/null 2>&1; then
+    python - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+  elif command -v uv >/dev/null 2>&1; then
+    uv run python - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+  else
+    date +%s
+  fi
+}
+
+# Resolve the active bearer token for client integrations.
+resolve_integration_bearer_token() {
+  local root_dir="${1:-$PWD}"
+  local token="${INTEGRATION_BEARER_TOKEN:-${HTTP_BEARER_TOKEN:-}}"
+  local runtime_token_file="/run/credentials/mcp-agent-mail.service/agent-mail-token"
+
+  if [[ -n "$token" ]]; then
+    printf '%s\n' "$token"
+    return 0
+  fi
+
+  if [[ -r "$runtime_token_file" ]]; then
+    token="$(tr -d '\r\n' < "$runtime_token_file")"
+    if [[ -n "$token" ]]; then
+      printf '%s\n' "$token"
+      return 0
+    fi
+  fi
+
+  local -a candidate_files=()
+  if [[ -n "$root_dir" ]]; then
+    candidate_files+=("${root_dir}/.env")
+  fi
+  if [[ -n "${MCP_AGENT_MAIL_ENV_FILE:-}" ]]; then
+    candidate_files+=("${MCP_AGENT_MAIL_ENV_FILE}")
+  fi
+  candidate_files+=("${HOME}/.config/mcp-agent-mail/config.env")
+
+  local file=""
+  for file in "${candidate_files[@]}"; do
+    [[ -f "$file" ]] || continue
+    token="$(read_env_file_value "$file" "HTTP_BEARER_TOKEN" || true)"
+    if [[ -n "$token" ]]; then
+      printf '%s\n' "$token"
+      return 0
+    fi
+  done
+
+  printf '\n'
+}
+
 # Atomic write: read content from stdin and atomically move to target
 write_atomic() {
   local target="$1"; shift || true
@@ -366,6 +434,45 @@ run_cmd() {
     return 0
   fi
   "$@"
+}
+
+# Write the standard local run helper used by integration scripts.
+write_run_helper_script() {
+  local target="$1"
+  write_atomic "$target" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "${ROOT_DIR}/scripts/lib.sh" ]]; then
+  # shellcheck disable=SC1090
+  . "${ROOT_DIR}/scripts/lib.sh"
+fi
+
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]] && declare -F resolve_integration_bearer_token >/dev/null 2>&1; then
+  HTTP_BEARER_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
+fi
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
+  if declare -F generate_bearer_token >/dev/null 2>&1; then
+    HTTP_BEARER_TOKEN="$(generate_bearer_token)"
+  elif command -v openssl >/dev/null 2>&1; then
+    HTTP_BEARER_TOKEN="$(openssl rand -hex 32)"
+  elif command -v uv >/dev/null 2>&1; then
+    HTTP_BEARER_TOKEN="$(uv run python - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  else
+    HTTP_BEARER_TOKEN="$(date +%s)"
+  fi
+fi
+export HTTP_BEARER_TOKEN
+
+cd "${ROOT_DIR}"
+uv run python -m mcp_agent_mail.cli serve-http "$@"
+SH
+  set_secure_exec "$target" || true
 }
 
 # Backup a file to backup_config_files/ with timestamp before .bak extension
@@ -706,4 +813,3 @@ kill_port_processes() {
     fi
   fi
 }
-


### PR DESCRIPTION
## What changed

This updates the shell integration installers so they resolve the active bearer token from the live runtime credential path before falling back to local env files, and it centralizes the generated run-helper script in `scripts/lib.sh`.

It also fixes the user-level Cursor, Gemini CLI, and Factory Droid MCP config writers so they keep the `Authorization` header when a token is available instead of writing unauthenticated HTTP configs.

## Why it changed

The running Agent Mail service can be using a bearer token projected by systemd at `/run/credentials/mcp-agent-mail.service/agent-mail-token`, while several integration scripts only looked at `INTEGRATION_BEARER_TOKEN` or project `.env` state.

That mismatch lets re-runs of the installers emit stale or unauthenticated client configs even when the live service is healthy and enforcing a different token.

## Impact

Re-running the installers now prefers the live runtime token, so regenerated MCP configs stay aligned with the service that is actually running.

This reduces auth drift across Codex, Claude Code, Cursor, Gemini CLI, Factory Droid, Windsurf, OpenCode, Cline, and GitHub Copilot integrations, and fixes the concrete header omission in the user-level Cursor/Gemini/Factory writers.

## Root cause

Installer-side token resolution was not using the runtime systemd credential as a source of truth, and a few user-level config writers dropped the auth header entirely.

## Validation

- `bash -n scripts/lib.sh scripts/integrate_cursor.sh scripts/integrate_gemini_cli.sh scripts/integrate_factory_droid.sh scripts/integrate_windsurf.sh scripts/integrate_opencode.sh scripts/integrate_github_copilot.sh scripts/integrate_codex_cli.sh scripts/integrate_cline.sh scripts/integrate_claude_code.sh`
- Verified on a live host that regenerated configs align with the runtime bearer token and authenticated MCP calls succeed.
