### PR TITLE
[codex] Allow registering explicit identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Modern projects often run multiple coding agents at once (backend, frontend, scr
 
 This project provides a lightweight, interoperable layer so agents can:
 
-- Register a temporary-but-persistent identity (e.g., GreenCastle)
+- Register a temporary-but-persistent identity (e.g., `cc-0` or `GreenCastle`)
 - Send/receive GitHub-Flavored Markdown messages with images
 - Search, summarize, and thread conversations
 - Declare advisory file reservations (leases) on files/globs to signal intent
@@ -1696,7 +1696,8 @@ sequenceDiagram
 ### Semantics & invariants
 
 - Identity
-  - Names are memorable adjective+noun and unique per project; `name_hint` is sanitized (alnum) and used if available
+  - Explicit identities are unique per project and must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`
+  - If `name`/`name_hint` is omitted, the server auto-generates a unique adjective+noun identity
   - `whois` returns the stored profile; `list_agents` can filter by recent activity
   - `last_active_ts` is bumped on relevant interactions (messages, inbox checks, etc.)
 - Threads
@@ -2116,7 +2117,7 @@ Common variables you may set:
 | `QUOTA_ATTACHMENTS_LIMIT_BYTES` | `0` | Max attachment storage per project (0=unlimited) |
 | `QUOTA_INBOX_LIMIT_COUNT` | `0` | Max inbox messages per agent (0=unlimited) |
 | `RETENTION_IGNORE_PROJECT_PATTERNS` | `demo,test*,testproj*,testproject,backendproj*,frontendproj*` | CSV of project patterns to ignore in retention/quota reports |
-| `AGENT_NAME_ENFORCEMENT_MODE` | `coerce` | Agent naming policy: `strict` (reject invalid adjective+noun names), `coerce` (auto-generate if invalid), `always_auto` (always auto-generate) |
+| `AGENT_NAME_ENFORCEMENT_MODE` | `coerce` | Identity policy: `strict`/`coerce` both honor valid explicit identities and reject invalid or reserved ones; `always_auto` always ignores caller-supplied names and auto-generates an adjective+noun identity |
 
 ## Development quick start
 

--- a/docs/IDENTITY_CONTRACT.md
+++ b/docs/IDENTITY_CONTRACT.md
@@ -179,4 +179,4 @@ The file-based identity contract documented here serves a different purpose: it 
 - File-based: for shell-level identity discovery (hooks, integration scripts, cron jobs).
 - DB-based: for server-level identity persistence (MCP tool calls, session continuity).
 
-A future enhancement could have `register_agent` in the server also call `identity-write.sh` to keep both systems in sync.
+Current integration scripts already write this file after a successful bootstrap registration so shell-side tooling can track either auto-generated adjective+noun names or explicit identities such as `cc-0`.

--- a/scripts/integrate_claude_code.sh
+++ b/scripts/integrate_claude_code.sh
@@ -139,21 +139,23 @@ if [[ ${_SERVER_AVAILABLE} -eq 1 ]]; then
     log_warn "Failed to ensure project"
   fi
 
-  # register_agent - DON'T pass a name, let server auto-generate adjective+noun name
-  # Capture response to extract the generated name
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "claude-code" "claude-sonnet" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
   _REGISTER_RESPONSE=$(curl -sS --connect-timeout 2 --max-time 5 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"claude-code\",\"model\":\"claude-sonnet\",\"task_description\":\"setup\"}}}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
       "${_URL}" 2>/dev/null || echo "")
 
   if [[ -n "${_REGISTER_RESPONSE}" ]]; then
-    # Extract agent name from JSON response using jq or Python
-    if command -v jq >/dev/null 2>&1; then
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.name // empty' 2>/dev/null || echo "")
-    else
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | uv run python -c 'import sys,json; r=json.load(sys.stdin); c=r.get("result",{}).get("content",[]); print(json.loads(c[0]["text"])["name"] if c else "")' 2>/dev/null || echo "")
-    fi
+    _AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
     if [[ -n "${_AGENT}" ]]; then
       log_ok "Registered agent: ${_AGENT}"
+      persist_agent_identity_file "${ROOT_DIR}" "${_AGENT}" "${TARGET_DIR}"
     else
       log_warn "Could not parse agent name from response"
     fi

--- a/scripts/integrate_cline.sh
+++ b/scripts/integrate_cline.sh
@@ -137,7 +137,10 @@ else
   if [[ -n "${_TOKEN}" ]]; then _AUTH_ARGS+=("-H" "Authorization: Bearer ${_TOKEN}"); fi
 
   _HUMAN_KEY_ESCAPED=$(json_escape_string "${TARGET_DIR}") || { log_err "Failed to escape project path"; exit 1; }
-  _AGENT_ESCAPED=$(json_escape_string "${USER:-cline}") || { log_err "Failed to escape agent name"; exit 1; }
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
 
   if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
       -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":${_HUMAN_KEY_ESCAPED}}}}" \
@@ -147,10 +150,17 @@ else
     log_warn "Failed to ensure project (server may be starting)"
   fi
 
-  if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"cline\",\"model\":\"default\",\"name\":${_AGENT_ESCAPED},\"task_description\":\"setup\"}}}" \
-      "${_URL}" >/dev/null 2>&1; then
-    log_ok "Registered agent on server"
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "cline" "default" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
+  _REGISTER_RESPONSE=$(curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
+      "${_URL}" 2>/dev/null || echo "")
+  _REGISTERED_AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+  if [[ -n "${_REGISTERED_AGENT}" ]]; then
+    log_ok "Registered agent on server: ${_REGISTERED_AGENT}"
+    persist_agent_identity_file "${ROOT_DIR}" "${_REGISTERED_AGENT}" "${TARGET_DIR}"
   else
     log_warn "Failed to register agent (server may be starting)"
   fi
@@ -168,5 +178,4 @@ else
   _print "  - Header: (optional on localhost if server allows)"
 fi
 _print "Then start the server with: ${RUN_HELPER}"
-
 

--- a/scripts/integrate_codex_cli.sh
+++ b/scripts/integrate_codex_cli.sh
@@ -170,21 +170,23 @@ if readiness_poll "${_HTTP_HOST}" "${_HTTP_PORT}" "/health/readiness" 3 0.5; the
     log_warn "Failed to ensure project"
   fi
 
-  # register_agent - DON'T pass a name, let server auto-generate adjective+noun name
-  # Capture response to extract the generated name
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "codex-cli" "gpt-5-codex" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
   _REGISTER_RESPONSE=$(curl -sS --connect-timeout 2 --max-time 5 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"codex-cli\",\"model\":\"gpt-5-codex\",\"task_description\":\"setup\"}}}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
       "${_URL}" 2>/dev/null || echo "")
 
   if [[ -n "${_REGISTER_RESPONSE}" ]]; then
-    # Extract agent name from JSON response using jq or Python
-    if command -v jq >/dev/null 2>&1; then
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.name // empty' 2>/dev/null || echo "")
-    else
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | uv run python -c 'import sys,json; r=json.load(sys.stdin); c=r.get("result",{}).get("content",[]); print(json.loads(c[0]["text"])["name"] if c else "")' 2>/dev/null || echo "")
-    fi
+    _AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
     if [[ -n "${_AGENT}" ]]; then
       log_ok "Registered agent: ${_AGENT}"
+      persist_agent_identity_file "${ROOT_DIR}" "${_AGENT}" "${TARGET_DIR}"
     else
       log_warn "Could not parse agent name from response"
     fi

--- a/scripts/integrate_cursor.sh
+++ b/scripts/integrate_cursor.sh
@@ -149,7 +149,10 @@ else
   # Bug 6 fix: Use json_escape_string to safely escape variables
   # Issue #7 fix: Validate escaping succeeded
   _HUMAN_KEY_ESCAPED=$(json_escape_string "${TARGET_DIR}") || { log_err "Failed to escape project path"; exit 1; }
-  _AGENT_ESCAPED=$(json_escape_string "${USER:-cursor}") || { log_err "Failed to escape agent name"; exit 1; }
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
 
   # ensure_project - Bug 16 fix: add logging
   if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
@@ -160,13 +163,18 @@ else
     log_warn "Failed to ensure project (server may be starting)"
   fi
 
-  # register_agent - Bug 16 fix: add logging
-  if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"cursor\",\"model\":\"cursor\",\"name\":${_AGENT_ESCAPED},\"task_description\":\"setup\"}}}" \
-      "${_URL}" >/dev/null 2>&1; then
-    log_ok "Registered agent on server"
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "cursor" "cursor" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
+  _REGISTER_RESPONSE=$(curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
+      "${_URL}" 2>/dev/null || echo "")
+  _REGISTERED_AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+  if [[ -n "${_REGISTERED_AGENT}" ]]; then
+    log_ok "Registered agent on server: ${_REGISTERED_AGENT}"
+    persist_agent_identity_file "${ROOT_DIR}" "${_REGISTERED_AGENT}" "${TARGET_DIR}"
   else
     log_warn "Failed to register agent (server may be starting)"
   fi
 fi
-

--- a/scripts/integrate_factory_droid.sh
+++ b/scripts/integrate_factory_droid.sh
@@ -166,21 +166,23 @@ else
     log_warn "Failed to ensure project"
   fi
 
-  # register_agent - DON'T pass a name, let server auto-generate adjective+noun name
-  # Capture response to extract the generated name
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "factory-droid" "factory" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
   _REGISTER_RESPONSE=$(curl -sS --connect-timeout 2 --max-time 5 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"factory-droid\",\"model\":\"factory\",\"task_description\":\"setup\"}}}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
       "${_URL}" 2>/dev/null || echo "")
 
   if [[ -n "${_REGISTER_RESPONSE}" ]]; then
-    # Extract agent name from JSON response using jq or Python
-    if command -v jq >/dev/null 2>&1; then
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.name // empty' 2>/dev/null || echo "")
-    else
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | uv run python -c 'import sys,json; r=json.load(sys.stdin); c=r.get("result",{}).get("content",[]); print(json.loads(c[0]["text"])["name"] if c else "")' 2>/dev/null || echo "")
-    fi
+    _AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
     if [[ -n "${_AGENT}" ]]; then
       log_ok "Registered agent: ${_AGENT}"
+      persist_agent_identity_file "${ROOT_DIR}" "${_AGENT}" "${TARGET_DIR}"
     else
       log_warn "Could not parse agent name from response"
     fi

--- a/scripts/integrate_gemini_cli.sh
+++ b/scripts/integrate_gemini_cli.sh
@@ -201,21 +201,23 @@ else
     log_warn "Failed to ensure project"
   fi
 
-  # register_agent - DON'T pass a name, let server auto-generate adjective+noun name
-  # Capture response to extract the generated name
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "gemini-cli" "gemini" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
   _REGISTER_RESPONSE=$(curl -sS --connect-timeout 2 --max-time 5 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"gemini-cli\",\"model\":\"gemini\",\"task_description\":\"setup\"}}}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
       "${_URL}" 2>/dev/null || echo "")
 
   if [[ -n "${_REGISTER_RESPONSE}" ]]; then
-    # Extract agent name from JSON response using jq or Python
-    if command -v jq >/dev/null 2>&1; then
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.name // empty' 2>/dev/null || echo "")
-    else
-      _AGENT=$(echo "${_REGISTER_RESPONSE}" | uv run python -c 'import sys,json; r=json.load(sys.stdin); c=r.get("result",{}).get("content",[]); print(json.loads(c[0]["text"])["name"] if c else "")' 2>/dev/null || echo "")
-    fi
+    _AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
     if [[ -n "${_AGENT}" ]]; then
       log_ok "Registered agent: ${_AGENT}"
+      persist_agent_identity_file "${ROOT_DIR}" "${_AGENT}" "${TARGET_DIR}"
     else
       log_warn "Could not parse agent name from response"
     fi

--- a/scripts/integrate_github_copilot.sh
+++ b/scripts/integrate_github_copilot.sh
@@ -225,7 +225,10 @@ else
   if [[ -n "${_TOKEN}" ]]; then _AUTH_ARGS+=("-H" "Authorization: Bearer ${_TOKEN}"); fi
 
   _HUMAN_KEY_ESCAPED=$(json_escape_string "${TARGET_DIR}") || { log_err "Failed to escape project path"; exit 1; }
-  _AGENT_ESCAPED=$(json_escape_string "${USER:-copilot}") || { log_err "Failed to escape agent name"; exit 1; }
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
 
   if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
       -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":${_HUMAN_KEY_ESCAPED}}}}" \
@@ -235,10 +238,17 @@ else
     log_warn "Failed to ensure project (server may be starting)"
   fi
 
-  if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"github-copilot\",\"model\":\"gpt-4\",\"name\":${_AGENT_ESCAPED},\"task_description\":\"setup\"}}}" \
-      "${_URL}" >/dev/null 2>&1; then
-    log_ok "Registered agent on server"
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "github-copilot" "gpt-4" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
+  _REGISTER_RESPONSE=$(curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
+      "${_URL}" 2>/dev/null || echo "")
+  _REGISTERED_AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+  if [[ -n "${_REGISTERED_AGENT}" ]]; then
+    log_ok "Registered agent on server: ${_REGISTERED_AGENT}"
+    persist_agent_identity_file "${ROOT_DIR}" "${_REGISTERED_AGENT}" "${TARGET_DIR}"
   else
     log_warn "Failed to register agent (server may be starting)"
   fi
@@ -262,4 +272,3 @@ _print "  - URL: ${_URL}"
 _print "  - Header: Authorization: Bearer <token>"
 _print ""
 _print "Documentation: https://code.visualstudio.com/docs/copilot/customization/mcp-servers"
-

--- a/scripts/integrate_opencode.sh
+++ b/scripts/integrate_opencode.sh
@@ -194,7 +194,10 @@ else
   if [[ -n "${_TOKEN}" ]]; then _AUTH_ARGS+=("-H" "Authorization: Bearer ${_TOKEN}"); fi
 
   _HUMAN_KEY_ESCAPED=$(json_escape_string "${TARGET_DIR}") || { log_err "Failed to escape project path"; exit 1; }
-  _AGENT_ESCAPED=$(json_escape_string "${USER:-opencode}") || { log_err "Failed to escape agent name"; exit 1; }
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
 
   if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
       -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":${_HUMAN_KEY_ESCAPED}}}}" \
@@ -204,10 +207,17 @@ else
     log_warn "Failed to ensure project (server may be starting)"
   fi
 
-  if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"opencode\",\"model\":\"default\",\"name\":${_AGENT_ESCAPED},\"task_description\":\"setup\"}}}" \
-      "${_URL}" >/dev/null 2>&1; then
-    log_ok "Registered agent on server"
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "opencode" "default" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
+  _REGISTER_RESPONSE=$(curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
+      "${_URL}" 2>/dev/null || echo "")
+  _REGISTERED_AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+  if [[ -n "${_REGISTERED_AGENT}" ]]; then
+    log_ok "Registered agent on server: ${_REGISTERED_AGENT}"
+    persist_agent_identity_file "${ROOT_DIR}" "${_REGISTERED_AGENT}" "${TARGET_DIR}"
   else
     log_warn "Failed to register agent (server may be starting)"
   fi
@@ -223,5 +233,4 @@ _print "The MCP tools will be available to the AI agent alongside built-in tools
 _print ""
 _print "Start the server with: ${RUN_HELPER}"
 _print "Then launch OpenCode in this directory."
-
 

--- a/scripts/integrate_windsurf.sh
+++ b/scripts/integrate_windsurf.sh
@@ -137,7 +137,10 @@ else
   if [[ -n "${_TOKEN}" ]]; then _AUTH_ARGS+=("-H" "Authorization: Bearer ${_TOKEN}"); fi
 
   _HUMAN_KEY_ESCAPED=$(json_escape_string "${TARGET_DIR}") || { log_err "Failed to escape project path"; exit 1; }
-  _AGENT_ESCAPED=$(json_escape_string "${USER:-windsurf}") || { log_err "Failed to escape agent name"; exit 1; }
+  _REQUESTED_AGENT=$(requested_agent_name_override)
+  if [[ -n "${_REQUESTED_AGENT}" ]]; then
+    log_ok "Requesting explicit agent identity: ${_REQUESTED_AGENT}"
+  fi
 
   if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
       -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":${_HUMAN_KEY_ESCAPED}}}}" \
@@ -147,10 +150,17 @@ else
     log_warn "Failed to ensure project (server may be starting)"
   fi
 
-  if curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":${_HUMAN_KEY_ESCAPED},\"program\":\"windsurf\",\"model\":\"default\",\"name\":${_AGENT_ESCAPED},\"task_description\":\"setup\"}}}" \
-      "${_URL}" >/dev/null 2>&1; then
-    log_ok "Registered agent on server"
+  _REGISTER_ARGS=$(build_register_agent_arguments_json "${_HUMAN_KEY_ESCAPED}" "windsurf" "default" "setup" "${_REQUESTED_AGENT}") || {
+    log_err "Failed to build register_agent arguments"
+    exit 1
+  }
+  _REGISTER_RESPONSE=$(curl -fsS --connect-timeout 1 --max-time 2 --retry 0 -H "Content-Type: application/json" "${_AUTH_ARGS[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
+      "${_URL}" 2>/dev/null || echo "")
+  _REGISTERED_AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+  if [[ -n "${_REGISTERED_AGENT}" ]]; then
+    log_ok "Registered agent on server: ${_REGISTERED_AGENT}"
+    persist_agent_identity_file "${ROOT_DIR}" "${_REGISTERED_AGENT}" "${TARGET_DIR}"
   else
     log_warn "Failed to register agent (server may be starting)"
   fi
@@ -168,5 +178,4 @@ else
   _print "  - Header: (optional on localhost if server allows)"
 fi
 _print "Then start the server with: ${RUN_HELPER}"
-
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -165,6 +165,72 @@ json_escape_string() {
   echo "$result"
 }
 
+requested_agent_name_override() {
+  if [[ -n "${AGENT_NAME:-}" ]]; then
+    printf '%s\n' "${AGENT_NAME}"
+  fi
+}
+
+build_register_agent_arguments_json() {
+  local project_key_json="$1"
+  local program="$2"
+  local model="$3"
+  local task_description="$4"
+  local requested_name="${5:-}"
+  local program_json model_json task_json name_json
+
+  program_json=$(json_escape_string "$program") || return 1
+  model_json=$(json_escape_string "$model") || return 1
+  task_json=$(json_escape_string "$task_description") || return 1
+
+  if [[ -n "$requested_name" ]]; then
+    name_json=$(json_escape_string "$requested_name") || return 1
+    printf '"project_key":%s,"program":%s,"model":%s,"name":%s,"task_description":%s' \
+      "$project_key_json" "$program_json" "$model_json" "$name_json" "$task_json"
+    return 0
+  fi
+
+  printf '"project_key":%s,"program":%s,"model":%s,"task_description":%s' \
+    "$project_key_json" "$program_json" "$model_json" "$task_json"
+}
+
+extract_registered_agent_name() {
+  local response="$1"
+  local name=""
+
+  if [[ -z "$response" ]]; then
+    return 0
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    name=$(printf '%s' "$response" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.name // empty' 2>/dev/null || true)
+  else
+    name=$(printf '%s' "$response" | uv run python -c 'import json,sys; payload=json.load(sys.stdin); content=payload.get("result", {}).get("content", []); print(json.loads(content[0]["text"])["name"] if content else "")' 2>/dev/null || true)
+  fi
+
+  printf '%s\n' "$name"
+}
+
+persist_agent_identity_file() {
+  local root_dir="$1"
+  local agent_name="$2"
+  local project_dir="$3"
+  local identity_script="${root_dir}/scripts/identity-write.sh"
+
+  if [[ -z "$agent_name" || "$agent_name" == "YOUR_AGENT_NAME" ]]; then
+    return 0
+  fi
+  if [[ ! -x "$identity_script" ]]; then
+    log_warn "identity-write.sh not found or not executable; skipping pane identity sync."
+    return 0
+  fi
+  if "$identity_script" "$agent_name" "$project_dir" >/dev/null 2>&1; then
+    log_ok "Synced pane identity file for ${agent_name}"
+  else
+    log_warn "Failed to sync pane identity file for ${agent_name}"
+  fi
+}
+
 # Merge MCP server config into existing settings JSON
 # Usage: json_merge_mcp_server <existing_json> <server_name> <server_config_json>
 # Returns: merged JSON preserving all existing keys
@@ -706,4 +772,3 @@ kill_port_processes() {
     fi
   fi
 }
-

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -86,9 +86,10 @@ from .storage import (
 )
 from .utils import (
     generate_agent_name,
+    normalize_explicit_agent_name,
     sanitize_agent_name,
     slugify,
-    validate_agent_name_format,
+    validate_explicit_agent_name_format,
     validate_thread_id_format,
 )
 
@@ -2543,22 +2544,6 @@ def _detect_agent_name_mistake(value: str) -> tuple[str, str] | None:
             f"'{value}' looks like a broadcast attempt. Agent Mail doesn't support broadcasting to all agents. "
             f"List specific recipient agent names in the 'to' parameter."
         )
-    if _looks_like_descriptive_name(value):
-        return (
-            "DESCRIPTIVE_NAME",
-            f"'{value}' looks like a descriptive role name. Agent names must be randomly generated "
-            f"adjective+noun combinations like 'WhiteMountain' or 'BrownCreek', NOT descriptive of the agent's task. "
-            f"Omit the 'name' parameter to auto-generate a valid name."
-        )
-    if _looks_like_unix_username(value):
-        return (
-            "UNIX_USERNAME_AS_AGENT",
-            f"'{value}' looks like a Unix username (possibly from $USER environment variable). "
-            f"Agent names must be adjective+noun combinations like 'BlueLake' or 'GreenCastle'. "
-            f"When you called register_agent, the system likely auto-generated a valid name for you. "
-            f"To find your actual agent name, check the response from register_agent or use "
-            f"resource://agents/{{project_key}} to list all registered agents in this project."
-        )
     return None
 
 
@@ -3087,7 +3072,6 @@ def _validate_window_uuid(value: str) -> bool:
 async def _generate_unique_agent_name(
     project: Project,
     settings: Settings,
-    name_hint: Optional[str] = None,
 ) -> str:
     archive = await ensure_archive(settings, project.slug)
 
@@ -3097,39 +3081,87 @@ async def _generate_unique_agent_name(
         candidate_path = archive.root / "agents" / candidate
         return not await asyncio.to_thread(candidate_path.exists)
 
-    mode = getattr(settings, "agent_name_enforcement_mode", "coerce").lower()
-    if name_hint:
-        sanitized = sanitize_agent_name(name_hint)
-        if mode == "always_auto":
-            sanitized = None
-        if sanitized:
-            # When coercing, if the provided hint is not in the valid adjective+noun set,
-            # silently fall back to auto-generation instead of erroring.
-            if validate_agent_name_format(sanitized):
-                if not await available(sanitized):
-                    # In strict mode, indicate conflict; in coerce, fall back to generation
-                    if mode == "strict":
-                        raise ValueError(f"Agent name '{sanitized}' is already in use.")
-                else:
-                    return sanitized
-            else:
-                if mode == "strict":
-                    raise ValueError(
-                        f"Invalid agent name format: '{sanitized}'. "
-                        f"Agent names MUST be randomly generated adjective+noun combinations "
-                        f"(e.g., 'GreenLake', 'BlueDog'), NOT descriptive names. "
-                        f"Omit the 'name_hint' parameter to auto-generate a valid name."
-                    )
-        else:
-            # No alphanumerics remain; only strict mode should error
-            if mode == "strict":
-                raise ValueError("Name hint must contain alphanumeric characters.")
-
     for _ in range(1024):
         candidate = sanitize_agent_name(generate_agent_name())
         if candidate and await available(candidate):
             return candidate
     raise RuntimeError("Unable to generate a unique agent name.")
+
+
+async def _agent_name_available(
+    project: Project,
+    settings: Settings,
+    candidate: str,
+) -> bool:
+    archive = await ensure_archive(settings, project.slug)
+    if await _agent_name_exists(project, candidate):
+        return False
+    candidate_path = archive.root / "agents" / candidate
+    return not await asyncio.to_thread(candidate_path.exists)
+
+
+def _invalid_explicit_agent_name_message(label: str, value: str) -> str:
+    return (
+        f"Invalid {label}: '{value}'. "
+        "Explicit agent identities must start with an ASCII letter or digit and may contain only "
+        "ASCII letters, digits, '.', '_' and '-'."
+    )
+
+
+def _raise_invalid_explicit_agent_name(value: str, *, label: str, error_type: str = "INVALID_AGENT_NAME") -> None:
+    mistake = _detect_agent_name_mistake(value)
+    if mistake is not None:
+        raise ToolExecutionError(
+            mistake[0],
+            mistake[1],
+            recoverable=True,
+            data={
+                "provided_name": value,
+                "parameter": label,
+                "allowed_pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            },
+        )
+    raise ToolExecutionError(
+        error_type,
+        _invalid_explicit_agent_name_message(label, value),
+        recoverable=True,
+        data={
+            "provided_name": value,
+            "parameter": label,
+            "allowed_pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+        },
+    )
+
+
+async def _resolve_explicit_agent_name(
+    project: Project,
+    settings: Settings,
+    requested_name: str,
+    *,
+    label: str,
+    require_available: bool = False,
+) -> str:
+    candidate = normalize_explicit_agent_name(requested_name)
+    if candidate is None:
+        raise ToolExecutionError(
+            "INVALID_AGENT_NAME",
+            f"{label.capitalize()} cannot be empty.",
+            recoverable=True,
+            data={"provided_name": requested_name, "parameter": label},
+        )
+    if not validate_explicit_agent_name_format(candidate):
+        _raise_invalid_explicit_agent_name(candidate, label=label)
+    mistake = _detect_agent_name_mistake(candidate)
+    if mistake is not None:
+        _raise_invalid_explicit_agent_name(candidate, label=label)
+    if require_available and not await _agent_name_available(project, settings, candidate):
+        raise ToolExecutionError(
+            "AGENT_NAME_IN_USE",
+            f"Agent identity '{candidate}' is already in use in project '{project.human_key}'.",
+            recoverable=True,
+            data={"provided_name": candidate, "parameter": label, "project": project.slug},
+        )
+    return candidate
 
 
 async def _create_agent_record(
@@ -3179,43 +3211,21 @@ async def _get_or_create_agent(
     # 4. No window ID, no explicit name -> auto-generate (current behavior)
 
     if mode == "always_auto" and not window_uuid:
-        desired_name = await _generate_unique_agent_name(project, settings, None)
+        desired_name = await _generate_unique_agent_name(project, settings)
     elif name is not None and mode != "always_auto":
         # Priority 1: Explicit name provided
-        sanitized = sanitize_agent_name(name)
-        if not sanitized:
-            if mode == "strict":
-                raise ValueError("Agent name must contain alphanumeric characters.")
-            desired_name = await _generate_unique_agent_name(project, settings, None)
-        else:
-            if validate_agent_name_format(sanitized):
-                desired_name = sanitized
-                explicit_name_used = True
-            else:
-                if mode == "strict":
-                    mistake = _detect_agent_name_mistake(sanitized)
-                    if mistake:
-                        raise ToolExecutionError(
-                            mistake[0],
-                            mistake[1],
-                            recoverable=True,
-                            data={"provided_name": sanitized, "valid_examples": ["BlueLake", "GreenCastle", "RedStone"]},
-                        )
-                    raise ToolExecutionError(
-                        "INVALID_AGENT_NAME",
-                        f"Invalid agent name format: '{sanitized}'. "
-                        f"Agent names MUST be randomly generated adjective+noun combinations "
-                        f"(e.g., 'GreenLake', 'BlueDog'), NOT descriptive names. "
-                        f"Omit the 'name' parameter to auto-generate a valid name.",
-                        recoverable=True,
-                        data={"provided_name": sanitized, "valid_examples": ["BlueLake", "GreenCastle", "RedStone"]},
-                    )
-                desired_name = await _generate_unique_agent_name(project, settings, None)
+        desired_name = await _resolve_explicit_agent_name(
+            project,
+            settings,
+            name,
+            label="name",
+        )
+        explicit_name_used = True
     elif window_uuid:
         # Priority 2/3: Window identity resolution
         if not _validate_window_uuid(window_uuid):
             logger.warning("MCP_AGENT_MAIL_WINDOW_ID is not a valid UUID: %s", window_uuid)
-            desired_name = await _generate_unique_agent_name(project, settings, None)
+            desired_name = await _generate_unique_agent_name(project, settings)
         else:
             window_identity = await _get_window_identity(project, window_uuid)
             if window_identity:
@@ -3225,13 +3235,13 @@ async def _get_or_create_agent(
                 await _touch_window_identity(window_identity, ttl_days)
             else:
                 # Priority 3: new window identity -> generate name and create identity
-                desired_name = await _generate_unique_agent_name(project, settings, None)
+                desired_name = await _generate_unique_agent_name(project, settings)
                 window_identity = await _create_window_identity(
                     project, window_uuid, desired_name, ttl_days,
                 )
     else:
         # Priority 4: no name, no window ID -> auto-generate
-        desired_name = await _generate_unique_agent_name(project, settings, None)
+        desired_name = await _generate_unique_agent_name(project, settings)
     await ensure_schema()
     newly_created = False
     async with get_session() as session:
@@ -3294,7 +3304,7 @@ async def _get_or_create_agent(
                     break
 
                 # Auto-generated name collision under concurrency: pick a new name and retry.
-                desired_name = await _generate_unique_agent_name(project, settings, None)
+                desired_name = await _generate_unique_agent_name(project, settings)
                 continue
         else:
             raise RuntimeError("Failed to create a unique agent after multiple retries.")
@@ -5499,15 +5509,6 @@ def build_mcp_server() -> FastMCP:
           refreshes `last_active_ts`.
         - A `profile.json` file is written under `agents/<Name>/` in the project archive.
 
-        CRITICAL: Agent Naming Rules
-        -----------------------------
-        - Agent names MUST be randomly generated adjective+noun combinations
-        - Examples: "GreenLake", "BlueDog", "RedStone", "PurpleBear"
-        - Names should be unique, easy to remember, and NOT descriptive
-        - INVALID examples: "BackendHarmonizer", "DatabaseMigrator", "UIRefactorer"
-        - The whole point: names should be memorable identifiers, not role descriptions
-        - Best practice: Omit the `name` parameter to auto-generate a valid name
-
         Parameters
         ----------
         project_key : str
@@ -5517,9 +5518,11 @@ def build_mcp_server() -> FastMCP:
         model : str
             The underlying model (e.g., "gpt5-codex", "opus-4.1").
         name : Optional[str]
-            MUST be a valid adjective+noun combination if provided (e.g., "BlueLake").
-            If omitted, a random valid name is auto-generated (RECOMMENDED).
-            Names are unique per project; passing the same name updates the profile.
+            Optional explicit identity to register exactly as provided (e.g., "cc-0", "BlueLake").
+            Explicit identities must start with an ASCII letter or digit and may contain only
+            ASCII letters, digits, '.', '_' and '-'. If omitted, a random adjective+noun name
+            is auto-generated. Names are unique per project; passing the same name updates
+            the profile.
         task_description : str
             Short description of current focus (shows up in directory listings).
 
@@ -5540,13 +5543,13 @@ def build_mcp_server() -> FastMCP:
         Register with explicit valid name:
         ```json
         {"jsonrpc":"2.0","id":"4","method":"tools/call","params":{"name":"register_agent","arguments":{
-          "project_key":"/data/projects/backend","program":"claude-code","model":"opus-4.1","name":"BlueLake","task_description":"Navbar redesign"
+          "project_key":"/data/projects/backend","program":"claude-code","model":"opus-4.1","name":"cc-0","task_description":"Navbar redesign"
         }}}
         ```
 
         Pitfalls
         --------
-        - Names MUST match the adjective+noun format or an error will be raised
+        - Explicit identities must match the safe-ID format described above or an error will be raised
         - Names are case-insensitive unique. If you see "already in use", pick another or omit `name`.
         - Use the same `project_key` consistently across cooperating agents.
         """
@@ -5567,8 +5570,11 @@ def build_mcp_server() -> FastMCP:
         ap = (attachments_policy or "auto").lower()
         if ap not in {"auto", "inline", "file"}:
             ap = "auto"
-        if name:
-            existing_agent = await _find_agent_optional(project, name)
+        requested_name = name
+        if name and getattr(settings, "agent_name_enforcement_mode", "coerce").lower() != "always_auto":
+            requested_name = normalize_explicit_agent_name(name) or name
+        if requested_name:
+            existing_agent = await _find_agent_optional(project, requested_name)
             if existing_agent is not None:
                 await _authenticate_agent(
                     ctx,
@@ -5578,7 +5584,7 @@ def build_mcp_server() -> FastMCP:
                     token_param="registration_token",
                     action="register_agent for an existing identity",
                 )
-        agent = await _get_or_create_agent(project, name, program, model, task_description, settings)
+        agent = await _get_or_create_agent(project, requested_name, program, model, task_description, settings)
         # Persist attachment policy if changed
         if getattr(agent, "attachments_policy", None) != ap:
             async with get_session() as session:
@@ -6245,16 +6251,8 @@ def build_mcp_server() -> FastMCP:
         How this differs from `register_agent`
         --------------------------------------
         - Always creates a new identity with a fresh unique name (never updates an existing one).
-        - `name_hint`, if provided, MUST be a valid adjective+noun combination and must be available,
-          otherwise an error is raised. Without a hint, a random adjective+noun name is generated.
-
-        CRITICAL: Agent Naming Rules
-        -----------------------------
-        - Agent names MUST be randomly generated adjective+noun combinations
-        - Examples: "GreenCastle", "BlueLake", "RedStone", "PurpleBear"
-        - Names should be unique, easy to remember, and NOT descriptive
-        - INVALID examples: "BackendHarmonizer", "DatabaseMigrator", "UIRefactorer"
-        - Best practice: Omit `name_hint` to auto-generate a valid name (RECOMMENDED)
+        - `name_hint`, if provided, MUST be an available explicit identity matching the same
+          safe-ID rules as `register_agent`. Without a hint, a random adjective+noun name is generated.
 
         When to use
         -----------
@@ -6278,14 +6276,23 @@ def build_mcp_server() -> FastMCP:
         With valid name hint:
         ```json
         {"jsonrpc":"2.0","id":"c1","method":"tools/call","params":{"name":"create_agent_identity","arguments":{
-          "project_key":"/data/projects/backend","program":"codex-cli","model":"gpt5-codex","name_hint":"GreenCastle",
+          "project_key":"/data/projects/backend","program":"codex-cli","model":"gpt5-codex","name_hint":"cc-0",
           "task_description":"DB migration spike"
         }}}
         ```
         """
         _validate_program_model(program, model)
         project = await _get_project_by_identifier(project_key)
-        unique_name = await _generate_unique_agent_name(project, settings, name_hint)
+        if name_hint is not None and getattr(settings, "agent_name_enforcement_mode", "coerce").lower() != "always_auto":
+            unique_name = await _resolve_explicit_agent_name(
+                project,
+                settings,
+                name_hint,
+                label="name_hint",
+                require_available=True,
+            )
+        else:
+            unique_name = await _generate_unique_agent_name(project, settings)
         ap = (attachments_policy or "auto").lower()
         if ap not in {"auto", "inline", "file"}:
             ap = "auto"
@@ -6397,7 +6404,8 @@ def build_mcp_server() -> FastMCP:
         window_uuid : str
             The UUID of the window identity to rename.
         new_display_name : str
-            New display name (must be a valid adjective+noun agent name).
+            New display name for the window identity. Must match the explicit agent
+            identity safe-ID format.
 
         Returns
         -------
@@ -6410,14 +6418,13 @@ def build_mcp_server() -> FastMCP:
                 f"Invalid window UUID format: '{window_uuid}'.",
                 recoverable=True,
             )
-        sanitized = sanitize_agent_name(new_display_name)
-        if not sanitized or not validate_agent_name_format(sanitized):
-            raise ToolExecutionError(
-                "INVALID_DISPLAY_NAME",
-                f"Display name must be a valid adjective+noun combination (e.g., 'BlueLake'). Got: '{new_display_name}'.",
-                recoverable=True,
-            )
         project = await _get_project_by_identifier(project_key)
+        sanitized = await _resolve_explicit_agent_name(
+            project,
+            settings,
+            new_display_name,
+            label="display name",
+        )
         await ensure_schema()
         now = _naive_utc()
         async with get_session() as session:
@@ -7775,7 +7782,7 @@ def build_mcp_server() -> FastMCP:
         if to is None and original.sender_id == sender.id:
             async with get_session() as _rsl_sx:
                 _rsl_result = await _rsl_sx.execute(
-                    _sa_select(Agent.name, Agent.project_id, MessageRecipient.kind)
+                    select(Agent.name, Agent.project_id, MessageRecipient.kind)
                     .join(Agent, MessageRecipient.agent_id == Agent.id)
                     .where(
                         cast(Any, MessageRecipient.message_id) == original.id,
@@ -8311,7 +8318,7 @@ def build_mcp_server() -> FastMCP:
             is_not_found = isinstance(exc, NoResultFound) or (
                 isinstance(exc, ToolExecutionError) and exc.error_type == "NOT_FOUND"
             )
-            if is_not_found and register_if_missing and validate_agent_name_format(target_name):
+            if is_not_found and register_if_missing and validate_explicit_agent_name_format(target_name):
                 # Create the missing target identity using provided metadata (best effort)
                 b = await _get_or_create_agent(
                     target_project,
@@ -9431,7 +9438,7 @@ def build_mcp_server() -> FastMCP:
                 is_not_found = isinstance(exc, NoResultFound) or (
                     isinstance(exc, ToolExecutionError) and exc.error_type == "NOT_FOUND"
                 )
-                if is_not_found and register_if_missing and validate_agent_name_format(real_target):
+                if is_not_found and register_if_missing and validate_explicit_agent_name_format(real_target):
                     settings = get_settings()
                     b = await _get_or_create_agent(
                         project,

--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -246,9 +246,8 @@ class Settings:
     retention_ignore_project_patterns: list[str]
     # Agent identity naming policy
     # Values: "strict" | "coerce" | "always_auto"
-    # - strict: reject invalid provided names (current hard-fail behavior)
-    # - coerce: ignore invalid provided names and auto-generate a valid one (default)
-    # - always_auto: ignore any provided name and always auto-generate
+    # - strict/coerce: honor valid explicit identities; reject invalid/reserved ones
+    # - always_auto: ignore any provided name and always auto-generate an adjective+noun identity
     agent_name_enforcement_mode: str
     # Messaging ergonomics
     # When true, attempt to register missing local recipients during send_message

--- a/src/mcp_agent_mail/utils.py
+++ b/src/mcp_agent_mail/utils.py
@@ -163,6 +163,7 @@ NOUNS: Iterable[str] = (
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _AGENT_NAME_RE = re.compile(r"[^A-Za-z0-9]+")
+_EXPLICIT_AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _THREAD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 # Pre-built frozenset of all valid agent names (lowercase) for O(1) validation lookup.
@@ -208,6 +209,20 @@ def validate_agent_name_format(name: str) -> bool:
 
     # O(1) lookup using pre-built frozenset (vs O(n*m) iteration)
     return name.lower() in _VALID_AGENT_NAMES
+
+
+def normalize_explicit_agent_name(value: str) -> Optional[str]:
+    """Normalize a caller-supplied explicit agent identity without rewriting it."""
+    candidate = (value or "").strip()
+    return candidate or None
+
+
+def validate_explicit_agent_name_format(name: str) -> bool:
+    """Validate a caller-supplied explicit agent identity."""
+    candidate = normalize_explicit_agent_name(name)
+    if candidate is None:
+        return False
+    return _EXPLICIT_AGENT_NAME_RE.fullmatch(candidate) is not None
 
 
 def sanitize_agent_name(value: str) -> Optional[str]:

--- a/tests/test_agent_name_validation.py
+++ b/tests/test_agent_name_validation.py
@@ -19,8 +19,10 @@ from mcp_agent_mail.utils import (
     ADJECTIVES,
     NOUNS,
     generate_agent_name,
+    normalize_explicit_agent_name,
     sanitize_agent_name,
     validate_agent_name_format,
+    validate_explicit_agent_name_format,
 )
 
 # ============================================================================
@@ -211,6 +213,48 @@ class TestSanitizeAgentName:
 
 
 # ============================================================================
+# Unit Tests: explicit agent identity validation
+# ============================================================================
+
+
+class TestExplicitAgentIdentityValidation:
+    """Test validation helpers for caller-supplied explicit identities."""
+
+    def test_normalize_explicit_agent_name_strips_outer_whitespace(self):
+        assert normalize_explicit_agent_name("  cc-0  ") == "cc-0"
+        assert normalize_explicit_agent_name("\tBlueLake\n") == "BlueLake"
+
+    def test_validate_explicit_agent_name_format_accepts_safe_ids(self):
+        valid_names = [
+            "cc-0",
+            "codex-main",
+            "alice_reviewer",
+            "BlueLake",
+            "agent.v2",
+            "A",
+        ]
+        for name in valid_names:
+            assert validate_explicit_agent_name_format(name), f"'{name}' should be valid"
+
+    def test_validate_explicit_agent_name_format_rejects_invalid_ids(self):
+        invalid_names = [
+            "",
+            "   ",
+            ".hidden",
+            "-agent",
+            "_agent",
+            "agent/name",
+            r"agent\name",
+            "agent name",
+            "agent@name",
+            "*" ,
+            "a" * 129,
+        ]
+        for name in invalid_names:
+            assert not validate_explicit_agent_name_format(name), f"'{name}' should be invalid"
+
+
+# ============================================================================
 # Integration Tests: Agent Registration with Valid Names
 # ============================================================================
 
@@ -249,11 +293,11 @@ async def test_register_agent_with_explicit_valid_name(isolated_env):
                 "project_key": "/test/names",
                 "program": "test-program",
                 "model": "test-model",
-                "name": "BlueMountain",
+                "name": "cc-0",
             },
         )
 
-        assert result.data["name"] == "BlueMountain"
+        assert result.data["name"] == "cc-0"
 
 
 @pytest.mark.asyncio
@@ -289,115 +333,46 @@ async def test_register_agent_case_insensitive_uniqueness(isolated_env):
         assert result2.data["id"] == result1.data["id"]
 
 
-# ============================================================================
-# Integration Tests: Agent Registration with Invalid Names (Coerce Mode - Default)
-# ============================================================================
-
-
 @pytest.mark.asyncio
-async def test_register_agent_coerces_invalid_descriptive_name(isolated_env):
-    """In coerce mode (default), invalid names auto-generate valid ones."""
+async def test_register_agent_rejects_invalid_explicit_name(isolated_env):
+    """register_agent should reject explicit identities with invalid characters."""
     server = build_mcp_server()
     async with Client(server) as client:
-        await client.call_tool("ensure_project", {"human_key": "/test/coerce"})
-
-        # In coerce mode, invalid name should trigger auto-generation
-        result = await client.call_tool(
-            "register_agent",
-            {
-                "project_key": "/test/coerce",
-                "program": "test",
-                "model": "test",
-                "name": "BackendHarmonizer",  # Invalid descriptive name
-            },
-        )
-
-        # Should get a valid auto-generated name, not the invalid one
-        agent_name = result.data["name"]
-        assert agent_name != "BackendHarmonizer", "Should not accept invalid name"
-        assert validate_agent_name_format(agent_name), f"Auto-generated '{agent_name}' should be valid"
-
-
-@pytest.mark.asyncio
-async def test_register_agent_coerces_program_name_as_agent(isolated_env):
-    """In coerce mode, program names as agent names get auto-generated."""
-    server = build_mcp_server()
-    async with Client(server) as client:
-        await client.call_tool("ensure_project", {"human_key": "/test/coerce"})
-
-        result = await client.call_tool(
-            "register_agent",
-            {
-                "project_key": "/test/coerce",
-                "program": "claude-code",
-                "model": "opus",
-                "name": "claude-code",  # Using program name as agent name
-            },
-        )
-
-        agent_name = result.data["name"]
-        assert agent_name != "claude-code", "Should not accept program name as agent name"
-        assert validate_agent_name_format(agent_name), f"Auto-generated '{agent_name}' should be valid"
-
-
-# ============================================================================
-# Integration Tests: Agent Registration with Invalid Names (Strict Mode)
-# ============================================================================
-
-
-@pytest.mark.asyncio
-async def test_register_agent_strict_rejects_invalid_descriptive_name(isolated_env, monkeypatch):
-    """In strict mode, register_agent should reject descriptive names."""
-    monkeypatch.setenv("AGENT_NAME_ENFORCEMENT_MODE", "strict")
-    # Clear cached settings to pick up the new env var
-    from mcp_agent_mail.config import clear_settings_cache
-
-    clear_settings_cache()
-
-    server = build_mcp_server()
-    async with Client(server) as client:
-        await client.call_tool("ensure_project", {"human_key": "/test/strict"})
+        await client.call_tool("ensure_project", {"human_key": "/test/invalid-name"})
 
         with pytest.raises(Exception) as exc_info:
             await client.call_tool(
                 "register_agent",
                 {
-                    "project_key": "/test/strict",
+                    "project_key": "/test/invalid-name",
                     "program": "test",
                     "model": "test",
-                    "name": "BackendHarmonizer",
+                    "name": "agent/name",
                 },
             )
 
-        error_msg = str(exc_info.value).lower()
-        assert "descriptive" in error_msg or "adjective" in error_msg or "invalid" in error_msg
+        assert "invalid" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio
-async def test_register_agent_strict_rejects_program_name_as_agent(isolated_env, monkeypatch):
-    """In strict mode, register_agent should reject program names as agent names."""
-    monkeypatch.setenv("AGENT_NAME_ENFORCEMENT_MODE", "strict")
-    from mcp_agent_mail.config import clear_settings_cache
-
-    clear_settings_cache()
-
+async def test_register_agent_rejects_program_name_as_explicit_identity(isolated_env):
+    """register_agent should reject obvious program names as explicit identities."""
     server = build_mcp_server()
     async with Client(server) as client:
-        await client.call_tool("ensure_project", {"human_key": "/test/strict"})
+        await client.call_tool("ensure_project", {"human_key": "/test/program-name"})
 
         with pytest.raises(Exception) as exc_info:
             await client.call_tool(
                 "register_agent",
                 {
-                    "project_key": "/test/strict",
+                    "project_key": "/test/program-name",
                     "program": "claude-code",
                     "model": "opus",
                     "name": "claude-code",
                 },
             )
 
-        error_msg = str(exc_info.value).lower()
-        assert "program" in error_msg or "adjective" in error_msg or "invalid" in error_msg
+        assert "program name" in str(exc_info.value).lower()
 
 
 # ============================================================================
@@ -431,7 +406,7 @@ async def test_create_agent_identity_generates_unique_names(isolated_env):
 
 @pytest.mark.asyncio
 async def test_create_agent_identity_with_valid_hint(isolated_env):
-    """create_agent_identity should accept valid name hints."""
+    """create_agent_identity should accept explicit safe IDs as name hints."""
     server = build_mcp_server()
     async with Client(server) as client:
         await client.call_tool("ensure_project", {"human_key": "/test/hint"})
@@ -442,61 +417,32 @@ async def test_create_agent_identity_with_valid_hint(isolated_env):
                 "project_key": "/test/hint",
                 "program": "test",
                 "model": "test",
-                "name_hint": "SilentCave",
+                "name_hint": "cc-0",
             },
         )
 
-        assert result.data["name"] == "SilentCave"
+        assert result.data["name"] == "cc-0"
 
 
 @pytest.mark.asyncio
-async def test_create_agent_identity_coerces_invalid_hint(isolated_env):
-    """In coerce mode, create_agent_identity auto-generates for invalid hints."""
+async def test_create_agent_identity_rejects_invalid_hint(isolated_env):
+    """create_agent_identity should reject invalid explicit identity hints."""
     server = build_mcp_server()
     async with Client(server) as client:
         await client.call_tool("ensure_project", {"human_key": "/test/hint"})
-
-        # In coerce mode, invalid hint should trigger auto-generation
-        result = await client.call_tool(
-            "create_agent_identity",
-            {
-                "project_key": "/test/hint",
-                "program": "test",
-                "model": "test",
-                "name_hint": "InvalidDescriptiveName",
-            },
-        )
-
-        agent_name = result.data["name"]
-        assert agent_name != "InvalidDescriptiveName", "Should not accept invalid hint"
-        assert validate_agent_name_format(agent_name), f"Auto-generated '{agent_name}' should be valid"
-
-
-@pytest.mark.asyncio
-async def test_create_agent_identity_strict_rejects_invalid_hint(isolated_env, monkeypatch):
-    """In strict mode, create_agent_identity should reject invalid name hints."""
-    monkeypatch.setenv("AGENT_NAME_ENFORCEMENT_MODE", "strict")
-    from mcp_agent_mail.config import clear_settings_cache
-
-    clear_settings_cache()
-
-    server = build_mcp_server()
-    async with Client(server) as client:
-        await client.call_tool("ensure_project", {"human_key": "/test/strict-hint"})
 
         with pytest.raises(Exception) as exc_info:
             await client.call_tool(
                 "create_agent_identity",
                 {
-                    "project_key": "/test/strict-hint",
+                    "project_key": "/test/hint",
                     "program": "test",
                     "model": "test",
-                    "name_hint": "InvalidDescriptiveName",
+                    "name_hint": "agent/name",
                 },
             )
 
-        error_msg = str(exc_info.value).lower()
-        assert "adjective" in error_msg or "invalid" in error_msg or "format" in error_msg
+        assert "invalid" in str(exc_info.value).lower()
 
 
 # ============================================================================

--- a/tests/test_mistake_detection.py
+++ b/tests/test_mistake_detection.py
@@ -5,8 +5,7 @@ These tests verify that the mistake detection helpers correctly identify:
 2. Model names mistakenly used as agent names
 3. Email addresses mistakenly used as agent names
 4. Broadcast attempts
-5. Descriptive role names
-6. Suspicious file reservation patterns
+5. Suspicious file reservation patterns
 """
 from __future__ import annotations
 
@@ -170,12 +169,13 @@ class TestDetectAgentNameMistake:
         assert result[0] == "BROADCAST_ATTEMPT"
         assert "broadcast" in result[1].lower()
 
-    def test_detects_descriptive_name(self):
-        """Should detect descriptive role names with helpful message."""
-        result = _detect_agent_name_mistake("BackendHarmonizer")
-        assert result is not None
-        assert result[0] == "DESCRIPTIVE_NAME"
-        assert "descriptive" in result[1].lower()
+    def test_descriptive_names_are_no_longer_treated_as_mistakes(self):
+        """Descriptive names should not be rejected by the mistake detector."""
+        assert _detect_agent_name_mistake("BackendHarmonizer") is None
+
+    def test_unix_usernames_are_no_longer_treated_as_mistakes(self):
+        """Unix-style usernames should not be rejected by the mistake detector."""
+        assert _detect_agent_name_mistake("david") is None
 
     def test_valid_agent_name_returns_none(self):
         """Valid agent names should return None (no mistake detected)."""

--- a/tests/test_project_agent_setup.py
+++ b/tests/test_project_agent_setup.py
@@ -434,7 +434,7 @@ async def test_create_agent_identity_always_creates_new(isolated_env):
 
 @pytest.mark.asyncio
 async def test_create_agent_identity_with_name_hint(isolated_env):
-    """create_agent_identity respects valid name_hint."""
+    """create_agent_identity respects valid explicit identity hints."""
     server = build_mcp_server()
     async with Client(server) as client:
         await client.call_tool("ensure_project", {"human_key": "/test/setup/hint"})
@@ -446,12 +446,12 @@ async def test_create_agent_identity_with_name_hint(isolated_env):
                 "project_key": "/test/setup/hint",
                 "program": "test",
                 "model": "test",
-                "name_hint": "GreenCastle",
+                "name_hint": "cc-0",
             },
         )
 
         # Should use the hint
-        assert result.data["name"] == "GreenCastle"
+        assert result.data["name"] == "cc-0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_window_identity.py
+++ b/tests/test_window_identity.py
@@ -357,7 +357,7 @@ async def test_list_window_identities(isolated_env, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_rename_window(isolated_env, monkeypatch):
-    """rename_window should update the display name."""
+    """rename_window should update the display name using the explicit-ID rules."""
     window_uuid = str(uuid.uuid4())
     monkeypatch.setenv("MCP_AGENT_MAIL_WINDOW_ID", window_uuid)
 
@@ -382,11 +382,11 @@ async def test_rename_window(isolated_env, monkeypatch):
             {
                 "project_key": "/test/window",
                 "window_uuid": window_uuid,
-                "new_display_name": "SilverFox",
+                "new_display_name": "cc-0",
             },
         )
 
-        assert result.data["display_name"] == "SilverFox"
+        assert result.data["display_name"] == "cc-0"
         assert result.data["old_display_name"] == old_name
 
 


### PR DESCRIPTION
Closes #140.

## Summary
- allow `register_agent`, `create_agent_identity`, and `rename_window` to use explicit safe IDs like `alpha-one` or `cc-0`
- keep adjective+noun generation only for omitted names and `always_auto` mode
- update bootstrap scripts to pass through `AGENT_NAME` and sync pane identity files after registration
- refresh docs and tests for the explicit-identity contract

## Root cause
Agent Mail treated caller-provided identities as adjective+noun names, and in the default mode it could silently replace an explicit request with a generated identity. That made it hard to relaunch short-lived agents onto stable identities and left orphaned auto-generated names behind.

## Validation
- `uv run pytest tests/test_agent_name_validation.py tests/test_project_agent_setup.py tests/test_window_identity.py tests/test_mistake_detection.py -k 'not resolves_symlinks'`
- `uv run ruff check --fix --unsafe-fixes`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uvx ty check`
- `bash -n scripts/lib.sh scripts/integrate_codex_cli.sh scripts/integrate_claude_code.sh scripts/integrate_gemini_cli.sh scripts/integrate_factory_droid.sh scripts/integrate_cursor.sh scripts/integrate_cline.sh scripts/integrate_github_copilot.sh scripts/integrate_opencode.sh scripts/integrate_windsurf.sh`

## Notes
- `tests/test_project_agent_setup.py::test_ensure_project_resolves_symlinks` is currently failing on the base branch and was excluded from the focused pytest run because it is unrelated to this feature.
