### PR TITLE
Fix Claude Code inbox-check hook: registration_token + JSON envelope output

### DIFF
--- a/scripts/hooks/check_inbox.sh
+++ b/scripts/hooks/check_inbox.sh
@@ -6,6 +6,7 @@
 # - Silent when no mail (saves tokens)
 # - Uses curl directly (avoids Python import overhead)
 # - Outputs a brief reminder only when there are unread messages
+# - Supports both plain-text (default) and JSON envelope output for Claude Code
 #
 # Usage in .claude/settings.json:
 #   "PostToolUse": [
@@ -13,11 +14,18 @@
 #   ]
 #
 # Environment variables:
-#   AGENT_MAIL_PROJECT   - Project key (absolute path)
-#   AGENT_MAIL_AGENT     - Agent name
-#   AGENT_MAIL_URL       - Server URL (default: http://127.0.0.1:8765/api/)
-#   AGENT_MAIL_TOKEN     - Bearer token
-#   AGENT_MAIL_INTERVAL  - Minimum seconds between checks (default: 120)
+#   AGENT_MAIL_PROJECT             - Project key (absolute path)
+#   AGENT_MAIL_AGENT               - Agent name
+#   AGENT_MAIL_URL                 - Server URL (default: http://127.0.0.1:8765/api/)
+#   AGENT_MAIL_TOKEN               - Principal bearer token (HTTP-level auth)
+#   AGENT_MAIL_REGISTRATION_TOKEN  - Per-agent registration token (required for fetch_inbox
+#                                    when called outside an authenticated MCP session,
+#                                    which is the normal case for hook invocations)
+#   AGENT_MAIL_INTERVAL            - Minimum seconds between checks (default: 120)
+#   AGENT_MAIL_HOOK_FORMAT         - Output format: "text" (default, terminal-friendly)
+#                                    or "json" (emits Claude Code hookSpecificOutput envelope
+#                                    so the inbox state surfaces as a system reminder
+#                                    in the agent's reasoning context, not just stdout)
 
 # Don't use set -e because grep returns 1 when no match
 set -uo pipefail
@@ -27,7 +35,9 @@ PROJECT="${AGENT_MAIL_PROJECT:-}"
 AGENT="${AGENT_MAIL_AGENT:-}"
 URL="${AGENT_MAIL_URL:-http://127.0.0.1:8765/api/}"
 TOKEN="${AGENT_MAIL_TOKEN:-}"
+REG_TOKEN="${AGENT_MAIL_REGISTRATION_TOKEN:-}"
 INTERVAL="${AGENT_MAIL_INTERVAL:-120}"
+HOOK_FORMAT="${AGENT_MAIL_HOOK_FORMAT:-text}"
 
 # Require project and agent
 if [[ -z "${PROJECT}" || -z "${AGENT}" ]]; then
@@ -69,6 +79,19 @@ json_escape() {
 PROJECT_JSON=$(json_escape "${PROJECT}")
 AGENT_JSON=$(json_escape "${AGENT}")
 
+# Build args object — include registration_token only if present.
+# Without registration_token, fetch_inbox returns:
+#   "Error calling tool 'fetch_inbox': fetch_inbox requires registration_token
+#    for agent 'X', unless this MCP session has already authenticated as that agent."
+# Since this hook runs as a direct curl POST (no persistent MCP session), per-agent
+# auth must be in the args, not just the bearer Authorization header.
+if [[ -n "${REG_TOKEN}" ]]; then
+  REG_TOKEN_JSON=$(json_escape "${REG_TOKEN}")
+  ARGS_JSON="{\"project_key\":${PROJECT_JSON},\"agent_name\":${AGENT_JSON},\"registration_token\":${REG_TOKEN_JSON},\"limit\":10,\"include_bodies\":false}"
+else
+  ARGS_JSON="{\"project_key\":${PROJECT_JSON},\"agent_name\":${AGENT_JSON},\"limit\":10,\"include_bodies\":false}"
+fi
+
 # Build curl command with proper auth
 CURL_ARGS=(-s --max-time 3 -X POST "${URL}" -H "Content-Type: application/json")
 if [[ -n "${TOKEN}" ]]; then
@@ -77,7 +100,7 @@ fi
 
 # Fetch inbox via MCP
 RESPONSE=$(curl "${CURL_ARGS[@]}" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"fetch_inbox\",\"arguments\":{\"project_key\":${PROJECT_JSON},\"agent_name\":${AGENT_JSON},\"limit\":10,\"include_bodies\":false}}}" 2>/dev/null || echo "")
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"tools/call\",\"params\":{\"name\":\"fetch_inbox\",\"arguments\":${ARGS_JSON}}}" 2>/dev/null || echo "")
 
 # Check if we got a valid response with messages
 if [[ -z "${RESPONSE}" ]]; then
@@ -89,28 +112,55 @@ if echo "${RESPONSE}" | grep -q '"isError":true'; then
   exit 0
 fi
 
-# Count messages (look for "subject" in the response which indicates message objects)
-MSG_COUNT=$(echo "${RESPONSE}" | grep -c '"subject"' 2>/dev/null || echo "0")
-MSG_COUNT="${MSG_COUNT//[^0-9]/}"  # Strip any non-numeric chars
+# Count messages and urgent ones using Python JSON parsing for accuracy.
+# (`grep -c` counts matching LINES; JSON-RPC responses are typically single-line,
+# so a single-line response with N message objects yields count=1, not N.)
+COUNTS=$(echo "${RESPONSE}" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    msgs = d.get("result", {}).get("structuredContent", {}).get("result", [])
+    if not isinstance(msgs, list):
+        print("0 0")
+        sys.exit(0)
+    total = len(msgs)
+    urgent = sum(1 for m in msgs if isinstance(m, dict) and m.get("importance") in ("urgent", "high"))
+    print(f"{total} {urgent}")
+except Exception:
+    print("0 0")
+' 2>/dev/null || echo "0 0")
+
+MSG_COUNT="${COUNTS%% *}"
+URGENT_COUNT="${COUNTS##* }"
 MSG_COUNT="${MSG_COUNT:-0}"
+URGENT_COUNT="${URGENT_COUNT:-0}"
 
 if [[ "${MSG_COUNT}" -gt 0 ]]; then
-  # Check for urgent messages (use -E for extended regex portability)
-  URGENT_COUNT=$(echo "${RESPONSE}" | grep -Ec '"importance":"(urgent|high)"' 2>/dev/null || echo "0")
-  URGENT_COUNT="${URGENT_COUNT//[^0-9]/}"
-  URGENT_COUNT="${URGENT_COUNT:-0}"
-
-  echo ""
-  echo "📬 === INBOX REMINDER ==="
   if [[ ${URGENT_COUNT} -gt 0 ]]; then
-    echo "⚠️  You have ${MSG_COUNT} message(s) in your inbox (${URGENT_COUNT} urgent/high priority)"
-    echo "   Use fetch_inbox to check your messages!"
+    MSG_TEXT="You have ${MSG_COUNT} message(s) in your inbox (${URGENT_COUNT} urgent/high priority). Use fetch_inbox to check your messages."
   else
-    echo "   You have ${MSG_COUNT} recent message(s) in your inbox."
-    echo "   Consider checking with fetch_inbox if you haven't lately."
+    MSG_TEXT="You have ${MSG_COUNT} recent message(s) in your inbox. Consider checking with fetch_inbox if you haven't lately."
   fi
-  echo "========================="
-  echo ""
+
+  if [[ "${HOOK_FORMAT}" == "json" ]]; then
+    # Emit Claude Code hookSpecificOutput envelope so the inbox reminder surfaces
+    # as a system reminder in the agent's reasoning context. Plain stdout from a
+    # PostToolUse hook is shown in the terminal but does NOT reach the Claude Code
+    # agent — only this JSON envelope does.
+    printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+      "$(printf '%s' "${MSG_TEXT}" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+  else
+    # Plain-text format (default) — terminal-friendly reminder
+    echo ""
+    echo "📬 === INBOX REMINDER ==="
+    if [[ ${URGENT_COUNT} -gt 0 ]]; then
+      echo "⚠️  ${MSG_TEXT}"
+    else
+      echo "   ${MSG_TEXT}"
+    fi
+    echo "========================="
+    echo ""
+  fi
 fi
 
 exit 0

--- a/scripts/integrate_claude_code.sh
+++ b/scripts/integrate_claude_code.sh
@@ -152,11 +152,18 @@ if [[ ${_SERVER_AVAILABLE} -eq 1 ]]; then
       -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{${_REGISTER_ARGS}}}}" \
       "${_URL}" 2>/dev/null || echo "")
 
+  _REG_TOKEN=""
   if [[ -n "${_REGISTER_RESPONSE}" ]]; then
     _AGENT=$(extract_registered_agent_name "${_REGISTER_RESPONSE}")
+    _REG_TOKEN=$(extract_registered_registration_token "${_REGISTER_RESPONSE}")
     if [[ -n "${_AGENT}" ]]; then
       log_ok "Registered agent: ${_AGENT}"
       persist_agent_identity_file "${ROOT_DIR}" "${_AGENT}" "${TARGET_DIR}"
+      if [[ -z "${_REG_TOKEN}" ]]; then
+        log_warn "Could not parse registration_token from response — fetch_inbox calls"
+        log_warn "from the inbox hook will fail. Re-run integrate_claude_code.sh after"
+        log_warn "verifying the server returns registration_token in register_agent."
+      fi
     else
       log_warn "Could not parse agent name from response"
     fi
@@ -173,10 +180,18 @@ if [[ -z "${_AGENT}" ]]; then
   log_warn "After starting the server, reconfigure with: ./scripts/integrate_claude_code.sh"
 fi
 
+# Default registration token to empty if we never set it (e.g. server unreachable)
+_REG_TOKEN="${_REG_TOKEN:-}"
+
 log_step "Writing MCP server config and hooks (merge, not overwrite)"
 
-# Build the inbox check command with environment variables
-INBOX_CHECK_CMD="AGENT_MAIL_PROJECT='${TARGET_DIR}' AGENT_MAIL_AGENT='${_AGENT}' AGENT_MAIL_URL='${_URL}' AGENT_MAIL_TOKEN='${_TOKEN}' AGENT_MAIL_INTERVAL='120' '${INBOX_HOOK}'"
+# Build the inbox check command with environment variables.
+# - AGENT_MAIL_REGISTRATION_TOKEN provides the per-agent auth needed by fetch_inbox
+#   (the bearer token alone is insufficient — see scripts/hooks/check_inbox.sh comments)
+# - AGENT_MAIL_HOOK_FORMAT=json emits a Claude Code hookSpecificOutput envelope so
+#   inbox state surfaces as a system reminder in the agent's reasoning context,
+#   not just as terminal stdout the agent never sees
+INBOX_CHECK_CMD="AGENT_MAIL_PROJECT='${TARGET_DIR}' AGENT_MAIL_AGENT='${_AGENT}' AGENT_MAIL_URL='${_URL}' AGENT_MAIL_TOKEN='${_TOKEN}' AGENT_MAIL_REGISTRATION_TOKEN='${_REG_TOKEN}' AGENT_MAIL_INTERVAL='120' AGENT_MAIL_HOOK_FORMAT='json' '${INBOX_HOOK}'"
 
 # ============================================================================
 # settings.json: HOOKS ONLY (no secrets, git-tracked)

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -763,6 +763,29 @@ extract_registered_agent_name() {
   echo "$name"
 }
 
+# Extract the per-agent registration_token from a register_agent response.
+# Sibling to extract_registered_agent_name above; needed by hook installers
+# (e.g. integrate_claude_code.sh) so PostToolUse(Bash) inbox-check hooks can
+# authenticate fetch_inbox calls with per-agent auth — direct curl POSTs from
+# hooks bypass any persistent MCP-session state, so the bearer token alone is
+# insufficient for fetch_inbox (server returns "fetch_inbox requires
+# registration_token for agent X, unless this MCP session has already
+# authenticated as that agent").
+extract_registered_registration_token() {
+  local response="$1"
+  if [[ -z "$response" ]]; then
+    echo ""
+    return
+  fi
+  local token=""
+  if command -v jq >/dev/null 2>&1; then
+    token=$(echo "$response" | jq -r '.result.content[0].text // empty' 2>/dev/null | jq -r '.registration_token // empty' 2>/dev/null || echo "")
+  else
+    token=$(echo "$response" | uv run python -c 'import sys,json; r=json.load(sys.stdin); c=r.get("result",{}).get("content",[]); print(json.loads(c[0]["text"]).get("registration_token","") if c else "")' 2>/dev/null || echo "")
+  fi
+  echo "$token"
+}
+
 # Write the agent identity to a discoverable file so shell tooling can find it.
 persist_agent_identity_file() {
   local root_dir="$1" agent_name="$2" target_dir="${3:-$1}"


### PR DESCRIPTION
## Summary
- pass `AGENT_MAIL_REGISTRATION_TOKEN` through to the `fetch_inbox` JSON-RPC args from `scripts/hooks/check_inbox.sh` (per-agent auth required when the call bypasses MCP-session state)
- emit a Claude Code `hookSpecificOutput.additionalContext` envelope when `AGENT_MAIL_HOOK_FORMAT=json`, so the inbox reminder lands in the agent's reasoning context as a system reminder instead of just terminal stdout
- replace `grep -c '"subject"'` line-count with Python JSON parsing for accurate message and urgent-message totals (single-line JSON-RPC responses always counted 1)
- update `scripts/integrate_claude_code.sh` to capture the per-agent `registration_token` from the `register_agent` response (new `extract_registered_registration_token` helper in `scripts/lib.sh`) and propagate both `AGENT_MAIL_REGISTRATION_TOKEN` and `AGENT_MAIL_HOOK_FORMAT=json` into the hook env

## Root cause
The PostToolUse(Bash) inbox-check hook was silently no-op'ing for every Claude Code agent it was meant to serve. Two layered bugs:

**Layer 1 — auth mismatch.** The hook makes a direct `curl POST` to `/api/`, which has no persistent MCP-session state. Calling `fetch_inbox` with only the principal bearer token returns:

> `Error calling tool 'fetch_inbox': fetch_inbox requires registration_token for agent X, unless this MCP session has already authenticated as that agent.`

So the hook needs the per-agent `registration_token` in the JSON-RPC args, not just the `Authorization: Bearer` header. The previous `integrate_claude_code.sh` extracted only `_AGENT` (agent name) from the `register_agent` response, dropping the `registration_token` that came back in the same payload.

**Layer 2 — output channel.** Even when the hook successfully fetched messages, the plain-text reminder wrote to stdout — which Claude Code shows in the user's terminal but does NOT inject into the agent's reasoning context. Only `hookSpecificOutput.additionalContext` (or `systemMessage`) JSON envelopes get surfaced as system reminders for the next turn. So the "inbox check hook for the agent" wasn't actually telling the agent anything.

Empirical confirmation: a Claude Code session was missing high-importance HumanOverseer messages for ~2 hours despite the hook being installed and firing on every Bash call. After the patch, the next Bash trigger surfaced the same messages immediately.

## Validation
- `bash -n scripts/hooks/check_inbox.sh scripts/integrate_claude_code.sh scripts/lib.sh` — all clean
- end-to-end on a live server (`mcp-agent-mail` v0.x running on Mac Mini, Tailscale-reachable):
  - hook fires on every Bash call within rate-limit window (`/tmp/mcp-mail-check-<AGENT>` updates as expected)
  - with `AGENT_MAIL_REGISTRATION_TOKEN` unset, `fetch_inbox` fails with the upstream error message and the hook silently exits — confirming the failure mode
  - with `AGENT_MAIL_REGISTRATION_TOKEN` set, `fetch_inbox` returns the message list and the hook prints the reminder
  - with `AGENT_MAIL_HOOK_FORMAT=json`, the next agent turn receives a `<system-reminder>` block containing the reminder text — confirming context injection works
  - count fix: a 3-message inbox now reports "3 message(s)" instead of "1 message(s)"
- backward-compatible defaults: `AGENT_MAIL_REGISTRATION_TOKEN` is optional (existing args shape preserved when unset); `AGENT_MAIL_HOOK_FORMAT` defaults to `text` (terminal-friendly output unchanged for non-Claude-Code consumers)

## Notes
- the `scripts/integrate_claude_code.sh` change flips `AGENT_MAIL_HOOK_FORMAT=json` for new installs, since Claude Code is the targeted runtime. Anyone who'd rather see the plain text in their terminal can drop that env var from the generated hook command after install.
- a few related observations from this debugging session that don't belong in this PR but are worth filing as separate issues if you'd like — happy to open them: (a) the 24h pending-contact-request expiry creates a real-world failure mode for async human-in-the-loop approvals, (b) `mail_inbox.html` has a stubbed-out unread/read state UI (`get unreadCount()` etc. are placeholder comments), and (c) `auto_contact_if_blocked=true` on `send_message` reads as "queue the message for delivery on contact approval" but only auto-creates the contact request — the message itself is dropped, requiring a re-send. Also happy to take any of these as follow-up PRs.
