### PR TITLE
feat(fetch): add unread_only filter to fetch_inbox and fetch_topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Format: entries are organized by version in reverse chronological order. Each ve
 
 ### Messaging and Coordination
 
+- **`unread_only` filter on `fetch_inbox` and `fetch_topic`** -- new boolean parameter that restricts results to messages this recipient has not yet explicitly marked read via `mark_message_read` or `acknowledge_message`. Default `false` preserves existing behavior. Filter is per-recipient (one recipient marking a message read does not hide it from another recipient), ANDs with `topic`/`since_ts`/`urgent_only`, and cuts token burn at scale for polling agents in multi-agent deployments.
 - **Broadcast and topic threads** -- all-agent visibility messaging with topic-based threading for coordination ([b4ad9fc](https://github.com/Dicklesworthstone/mcp_agent_mail/commit/b4ad9fc82070efd59f315807a83ca56ea345c616))
 - **On-demand project-wide message summarization** -- generate summaries across an entire project's message history ([ee53048](https://github.com/Dicklesworthstone/mcp_agent_mail/commit/ee5304819ef6316acaa17a1d721dd026841d1fc5))
 - **Contact enforcement optimization** -- batch queries for contact policy checks, SPA support ([8b6e67c](https://github.com/Dicklesworthstone/mcp_agent_mail/commit/8b6e67c574725e8304b44b11820287b25717547f))

--- a/README.md
+++ b/README.md
@@ -1662,7 +1662,7 @@ sequenceDiagram
 
 3) Check inbox
 
-- `fetch_inbox(project_key, agent_name, since_ts?, urgent_only?, include_bodies?, limit?)` returns recent messages, preserving thread_id where available.
+- `fetch_inbox(project_key, agent_name, since_ts?, urgent_only?, unread_only?, include_bodies?, limit?)` returns recent messages, preserving thread_id where available. Pass `unread_only=true` to skip messages this recipient has already explicitly marked read.
 - `acknowledge_message(project_key, agent_name, message_id)` marks acknowledgements.
 
 4) Avoid conflicts with file reservations (leases)
@@ -2289,7 +2289,7 @@ Output format (all tools/resources):
 | `respond_contact` | `respond_contact(project_key: str, to_agent: str, from_agent: str, accept: bool, from_project?: str, ttl_seconds?: int, registration_token?: str)` | Contact link dict | Approve or deny a contact request |
 | `list_contacts` | `list_contacts(project_key: str, agent_name: str, registration_token?: str)` | `list[dict]` | List outbound contact links with target-project and expiry audit metadata |
 | `set_contact_policy` | `set_contact_policy(project_key: str, agent_name: str, policy: str, registration_token?: str)` | Agent dict | Set policy: `open`, `auto`, `contacts_only`, `block_all` |
-| `fetch_inbox` | `fetch_inbox(project_key: str, agent_name: str, limit?: int, urgent_only?: bool, include_bodies?: bool, since_ts?: str, registration_token?: str)` | `list[dict]` | Non-mutating inbox read |
+| `fetch_inbox` | `fetch_inbox(project_key: str, agent_name: str, limit?: int, urgent_only?: bool, include_bodies?: bool, since_ts?: str, topic?: str, unread_only?: bool, registration_token?: str)` | `list[dict]` | Non-mutating inbox read. `unread_only=true` filters to messages where this recipient's `read_ts` is NULL. |
 | `mark_message_read` | `mark_message_read(project_key: str, agent_name: str, message_id: int, registration_token?: str)` | `{message_id, read, read_at}` | Per-recipient read receipt |
 | `acknowledge_message` | `acknowledge_message(project_key: str, agent_name: str, message_id: int, registration_token?: str)` | `{message_id, acknowledged, acknowledged_at, read_at}` | Sets ack and read |
 | `macro_start_session` | `macro_start_session(human_key: str, program: str, model: str, task_description?: str, agent_name?: str, registration_token?: str, file_reservation_paths?: list[str], file_reservation_reason?: str, file_reservation_ttl_seconds?: int, inbox_limit?: int)` | `{project, agent, file_reservations, inbox}` | Orchestrates ensure→register→optional file reservation→inbox fetch |

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -4213,6 +4213,7 @@ async def _list_inbox(
     include_bodies: bool,
     since_ts: Optional[str],
     topic: Optional[str] = None,
+    unread_only: bool = False,
 ) -> list[dict[str, Any]]:
     if project.id is None or agent.id is None:
         raise ValueError("Project and agent must have ids before listing inbox.")
@@ -4247,6 +4248,8 @@ async def _list_inbox(
                 stmt = stmt.where(Message.created_ts > _naive_utc(since_dt))
         if topic:
             stmt = stmt.where(cast(Any, func.lower(Message.topic)) == topic.lower())
+        if unread_only:
+            stmt = stmt.where(cast(Any, MessageRecipient.read_ts).is_(None))
         result = await session.execute(stmt)
         rows = result.all()
     messages: list[dict[str, Any]] = []
@@ -9020,6 +9023,7 @@ def build_mcp_server() -> FastMCP:
         include_bodies: bool = False,
         since_ts: Optional[str] = None,
         topic: Optional[str] = None,
+        unread_only: bool = False,
         registration_token: Optional[str] = None,
         format: Optional[str] = None,
     ) -> list[dict[str, Any]]:
@@ -9033,6 +9037,9 @@ def build_mcp_server() -> FastMCP:
         - `limit`: max number of messages (default 20)
         - `include_bodies`: include full Markdown bodies in the payloads
         - `topic`: filter to messages with this topic tag
+        - `unread_only`: when True, return only messages this recipient has not yet
+          explicitly marked read via `mark_message_read` or `acknowledge_message`.
+          Note: a bare `fetch_inbox` call does NOT mark messages read.
 
         Usage patterns
         --------------
@@ -9089,11 +9096,23 @@ def build_mcp_server() -> FastMCP:
                 token_param="registration_token",
                 action="fetch_inbox",
             )
-            items = await _list_inbox(project, agent, limit, urgent_only, include_bodies, since_ts, topic=topic)
+            items = await _list_inbox(
+                project,
+                agent,
+                limit,
+                urgent_only,
+                include_bodies,
+                since_ts,
+                topic=topic,
+                unread_only=unread_only,
+            )
             if settings.notifications.enabled:
                 with suppress(Exception):
                     await clear_notification_signal(settings, project.slug, agent.name)
-            await ctx.info(f"Fetched {len(items)} messages for '{agent.name}'. urgent_only={urgent_only}")
+            await ctx.info(
+                f"Fetched {len(items)} messages for '{agent.name}'. "
+                f"urgent_only={urgent_only} unread_only={unread_only}"
+            )
             return items
         except Exception as exc:
             _rich_error_panel("fetch_inbox", {"error": str(exc)})
@@ -9114,6 +9133,7 @@ def build_mcp_server() -> FastMCP:
         include_bodies: bool = True,
         since_ts: Optional[str] = None,
         agent_name: Optional[str] = None,
+        unread_only: bool = False,
         registration_token: Optional[str] = None,
         format: Optional[str] = None,
     ) -> list[dict[str, Any]]:
@@ -9132,6 +9152,13 @@ def build_mcp_server() -> FastMCP:
             Include full Markdown bodies in the payloads (default true).
         since_ts : Optional[str]
             ISO-8601 timestamp; only messages newer than this are returned.
+        unread_only : bool
+            When True, restrict to messages where the viewer is a recipient AND
+            has not yet explicitly marked the message read via `mark_message_read`
+            or `acknowledge_message`. Messages the viewer sent but is not a
+            recipient of are excluded under this flag because "unread" only has
+            meaning for a recipient row. A bare `fetch_topic` call does NOT mark
+            messages read.
 
         Returns
         -------
@@ -9185,6 +9212,22 @@ def build_mcp_server() -> FastMCP:
                 since_dt = _parse_iso(since_ts)
                 if since_dt:
                     stmt = stmt.where(Message.created_ts > _naive_utc(since_dt))
+            if unread_only:
+                # Scope to messages where the viewer has a recipient row that
+                # has not been explicitly marked read. This narrows beyond
+                # `_message_visible_to_agent_clause`, which also surfaces
+                # messages visible via thread / sender / broadcast even when
+                # the viewer has no MessageRecipient row. We alias here because
+                # the visibility clause already references MessageRecipient in
+                # an EXISTS subquery, and the unaliased outer join would
+                # auto-correlate against it.
+                viewer_recipient = aliased(MessageRecipient)
+                stmt = stmt.join(
+                    viewer_recipient, viewer_recipient.message_id == Message.id
+                ).where(
+                    viewer_recipient.agent_id == (viewer.id or 0),
+                    cast(Any, viewer_recipient.read_ts).is_(None),
+                )
             result = await session.execute(stmt)
             rows = result.all()
         messages: list[dict[str, Any]] = []

--- a/tests/test_unread_only_filter.py
+++ b/tests/test_unread_only_filter.py
@@ -1,0 +1,374 @@
+"""Tests for the `unread_only` filter on `fetch_inbox` and `fetch_topic`.
+
+Covers:
+- Regression guard: omitting/`False` returns the same set as before (no behavior change).
+- Basic filter: `True` returns only messages whose recipient row has `read_ts IS NULL`.
+- Per-recipient semantics: a message read by Agent A is still unread for Agent B.
+- AND-composition: combines correctly with `since_ts` and `topic` filters.
+- `fetch_topic`: same filter applies to topic-tagged mail per viewer.
+
+The unread definition matches the rest of the server: "never explicitly marked
+read via `mark_message_read` or `acknowledge_message`." A bare fetch does NOT
+mark read.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastmcp import Client
+
+from mcp_agent_mail.app import build_mcp_server
+
+logger = logging.getLogger(__name__)
+
+
+def _get_data(result):
+    if hasattr(result, "structured_content") and isinstance(result.structured_content, dict):
+        sc = result.structured_content.get("result")
+        if isinstance(sc, dict):
+            return sc
+    if hasattr(result, "data") and isinstance(result.data, dict):
+        return result.data
+    if isinstance(result, dict):
+        return result
+    return getattr(result, "data", result)
+
+
+def _get_list(result):
+    if hasattr(result, "structured_content") and isinstance(result.structured_content, dict):
+        sc = result.structured_content.get("result")
+        if isinstance(sc, list):
+            return sc
+    return list(getattr(result, "data", result))
+
+
+async def _setup(client, project_key: str, agent_names: list[str]) -> None:
+    """Register a project with N named agents."""
+    await client.call_tool("ensure_project", {"human_key": project_key})
+    for name in agent_names:
+        await client.call_tool(
+            "register_agent",
+            {
+                "project_key": project_key,
+                "program": "test-prog",
+                "model": "test-model",
+                "name": name,
+            },
+        )
+
+
+# ============================================================================
+# fetch_inbox: unread_only filter
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_inbox_unread_only_false_is_regression_safe(isolated_env):
+    """Default behavior preserved: `unread_only=False` returns the same set as omitting it."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-regression"
+        await _setup(client, project, ["GreenCastle", "RedStone"])
+
+        # Send 3 messages, mark one read.
+        sent_ids = []
+        for i in range(3):
+            res = await client.call_tool(
+                "send_message",
+                {
+                    "project_key": project,
+                    "sender_name": "GreenCastle",
+                    "to": ["RedStone"],
+                    "subject": f"msg-{i}",
+                    "body_md": "x",
+                },
+            )
+            sent_ids.append(int(_get_data(res)["deliveries"][0]["payload"]["id"]))
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": sent_ids[0]},
+        )
+
+        without_flag = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {"project_key": project, "agent_name": "RedStone"},
+            )
+        )
+        explicit_false = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {"project_key": project, "agent_name": "RedStone", "unread_only": False},
+            )
+        )
+
+        assert {m["id"] for m in without_flag} == {m["id"] for m in explicit_false}
+        assert {m["id"] for m in without_flag} == set(sent_ids)
+
+
+@pytest.mark.asyncio
+async def test_fetch_inbox_unread_only_true_filters_to_unread(isolated_env):
+    """`unread_only=True` returns only messages where this recipient's `read_ts IS NULL`."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-basic"
+        await _setup(client, project, ["GreenCastle", "RedStone"])
+
+        # Send 3 messages.
+        sent_ids = []
+        for i in range(3):
+            res = await client.call_tool(
+                "send_message",
+                {
+                    "project_key": project,
+                    "sender_name": "GreenCastle",
+                    "to": ["RedStone"],
+                    "subject": f"msg-{i}",
+                    "body_md": "x",
+                },
+            )
+            sent_ids.append(int(_get_data(res)["deliveries"][0]["payload"]["id"]))
+
+        # Mark first explicitly read; ack second (which sets read_ts internally).
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": sent_ids[0]},
+        )
+        await client.call_tool(
+            "acknowledge_message",
+            {"project_key": project, "agent_name": "RedStone", "message_id": sent_ids[1]},
+        )
+
+        unread = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {"project_key": project, "agent_name": "RedStone", "unread_only": True},
+            )
+        )
+
+        unread_ids = {m["id"] for m in unread}
+        assert unread_ids == {sent_ids[2]}, f"expected only msg-2 unread, got {unread_ids}"
+
+
+@pytest.mark.asyncio
+async def test_fetch_inbox_unread_only_is_per_recipient_not_per_message(isolated_env):
+    """A message read by one recipient must still appear unread for another recipient."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-per-recipient"
+        await _setup(client, project, ["GreenCastle", "RedStone", "BlueLake"])
+
+        # One message addressed to both RedStone and BlueLake.
+        res = await client.call_tool(
+            "send_message",
+            {
+                "project_key": project,
+                "sender_name": "GreenCastle",
+                "to": ["RedStone", "BlueLake"],
+                "subject": "shared",
+                "body_md": "x",
+            },
+        )
+        msg_id = int(_get_data(res)["deliveries"][0]["payload"]["id"])
+
+        # RedStone reads it; BlueLake does not.
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": msg_id},
+        )
+
+        red_unread = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {"project_key": project, "agent_name": "RedStone", "unread_only": True},
+            )
+        )
+        blue_unread = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {"project_key": project, "agent_name": "BlueLake", "unread_only": True},
+            )
+        )
+
+        assert msg_id not in {m["id"] for m in red_unread}, "RedStone marked it read; should be filtered out for them"
+        assert msg_id in {m["id"] for m in blue_unread}, "BlueLake never read it; should still appear unread for them"
+
+
+@pytest.mark.asyncio
+async def test_fetch_inbox_unread_only_combines_with_since_ts_and_topic(isolated_env):
+    """`unread_only` ANDs with `since_ts` and `topic` — all filters must hold."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-combined"
+        await _setup(client, project, ["GreenCastle", "RedStone"])
+
+        # Send four messages with different topics; capture timestamps.
+        ids: dict[str, int] = {}
+        timestamps: dict[str, str] = {}
+        for label, topic in [("a", "alpha"), ("b", "alpha"), ("c", "beta"), ("d", "beta")]:
+            res = await client.call_tool(
+                "send_message",
+                {
+                    "project_key": project,
+                    "sender_name": "GreenCastle",
+                    "to": ["RedStone"],
+                    "subject": label,
+                    "body_md": "x",
+                    "topic": topic,
+                },
+            )
+            payload = _get_data(res)["deliveries"][0]["payload"]
+            ids[label] = int(payload["id"])
+            timestamps[label] = payload["created_ts"]
+
+        # Mark "a" read; topic=alpha; "b" still unread on alpha.
+        # Mark "c" read; topic=beta;  "d" still unread on beta.
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": ids["a"]},
+        )
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": ids["c"]},
+        )
+
+        # Filter: unread_only + topic=alpha → only "b".
+        alpha_unread = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {
+                    "project_key": project,
+                    "agent_name": "RedStone",
+                    "unread_only": True,
+                    "topic": "alpha",
+                },
+            )
+        )
+        assert {m["id"] for m in alpha_unread} == {ids["b"]}
+
+        # Filter: unread_only + since_ts=after(b) → only "d" (only unread strictly newer than b).
+        after_b_unread = _get_list(
+            await client.call_tool(
+                "fetch_inbox",
+                {
+                    "project_key": project,
+                    "agent_name": "RedStone",
+                    "unread_only": True,
+                    "since_ts": timestamps["b"],
+                },
+            )
+        )
+        assert {m["id"] for m in after_b_unread} == {ids["d"]}
+
+
+# ============================================================================
+# fetch_topic: unread_only filter
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_topic_unread_only_filters_per_viewer(isolated_env):
+    """`fetch_topic` with `unread_only=True` returns only topic messages where the viewer has unread."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-topic"
+        await _setup(client, project, ["GreenCastle", "RedStone"])
+
+        # Two messages, same topic, both addressed to RedStone.
+        ids: list[int] = []
+        for label in ["m1", "m2"]:
+            res = await client.call_tool(
+                "send_message",
+                {
+                    "project_key": project,
+                    "sender_name": "GreenCastle",
+                    "to": ["RedStone"],
+                    "subject": label,
+                    "body_md": "x",
+                    "topic": "standup",
+                },
+            )
+            ids.append(int(_get_data(res)["deliveries"][0]["payload"]["id"]))
+
+        # RedStone reads m1.
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": ids[0]},
+        )
+
+        # Without flag: both messages.
+        all_topic = _get_list(
+            await client.call_tool(
+                "fetch_topic",
+                {
+                    "project_key": project,
+                    "topic_name": "standup",
+                    "agent_name": "RedStone",
+                },
+            )
+        )
+        assert {m["id"] for m in all_topic} == set(ids)
+
+        # With flag: only m2 unread for RedStone.
+        only_unread = _get_list(
+            await client.call_tool(
+                "fetch_topic",
+                {
+                    "project_key": project,
+                    "topic_name": "standup",
+                    "agent_name": "RedStone",
+                    "unread_only": True,
+                },
+            )
+        )
+        assert {m["id"] for m in only_unread} == {ids[1]}
+
+
+@pytest.mark.asyncio
+async def test_fetch_topic_unread_only_combines_with_since_ts(isolated_env):
+    """`fetch_topic` ANDs `unread_only` with `since_ts` (mirrors the inbox combined test)."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        project = "/test/unread-topic-since"
+        await _setup(client, project, ["GreenCastle", "RedStone"])
+
+        ids: list[int] = []
+        timestamps: list[str] = []
+        for label in ["m1", "m2", "m3"]:
+            res = await client.call_tool(
+                "send_message",
+                {
+                    "project_key": project,
+                    "sender_name": "GreenCastle",
+                    "to": ["RedStone"],
+                    "subject": label,
+                    "body_md": "x",
+                    "topic": "release",
+                },
+            )
+            payload = _get_data(res)["deliveries"][0]["payload"]
+            ids.append(int(payload["id"]))
+            timestamps.append(payload["created_ts"])
+
+        # All three unread; since_ts > m1 should narrow to {m2, m3}.
+        # Then mark m2 read; with unread_only=True the result becomes {m3} only.
+        await client.call_tool(
+            "mark_message_read",
+            {"project_key": project, "agent_name": "RedStone", "message_id": ids[1]},
+        )
+
+        result = _get_list(
+            await client.call_tool(
+                "fetch_topic",
+                {
+                    "project_key": project,
+                    "topic_name": "release",
+                    "agent_name": "RedStone",
+                    "since_ts": timestamps[0],
+                    "unread_only": True,
+                },
+            )
+        )
+        assert {m["id"] for m in result} == {ids[2]}


### PR DESCRIPTION
## Summary

Adds an `unread_only: bool = False` parameter to `fetch_inbox` and `fetch_topic`. When `True`, the result is restricted to messages the calling recipient has not yet explicitly marked read via `mark_message_read` or `acknowledge_message`. Default `false` preserves current behavior.

## Why

Polling agents (Claude Code, Codex, Mac/MacBook clients in multi-agent deployments) re-fetch 20+ messages on every session start because the existing filters (`urgent_only`, `since_ts`, `topic`) don't capture per-recipient read state. This re-runs prompt-context against already-acknowledged mail. The DB already tracks read state per-recipient via `message_recipients.read_ts` (set by `mark_message_read` and `acknowledge_message`); this PR exposes it as a query filter so callers can opt in.

Token burn at scale across multi-agent deployments is the practical motivation. Useful for hooks that want to surface only new mail to the agent.

## Implementation

**`_list_inbox` (used by `fetch_inbox`)** — the existing query already JOINs `message_recipients` filtered to the requesting agent (`agent_id == agent.id`). Adding `WHERE read_ts IS NULL` to that same scope is a one-line narrow:

```python
if unread_only:
    stmt = stmt.where(cast(Any, MessageRecipient.read_ts).is_(None))
```

The existing `idx_message_recipients_agent_message` (`agent_id`, `message_id`) index keeps the JOIN cheap.

**`fetch_topic`** — this query did NOT previously join `message_recipients` (it returns topic-tagged messages visible to the viewer via `_message_visible_to_agent_clause`, which is sender_id OR a recipient EXISTS subquery). Under `unread_only=True` the implementation adds a fresh JOIN, **aliased** to avoid auto-correlation with the EXISTS subquery (without the alias, SQLAlchemy emits `Select returned no FROM clauses due to auto-correlation`):

```python
if unread_only:
    viewer_recipient = aliased(MessageRecipient)
    stmt = stmt.join(
        viewer_recipient, viewer_recipient.message_id == Message.id
    ).where(
        viewer_recipient.agent_id == (viewer.id or 0),
        cast(Any, viewer_recipient.read_ts).is_(None),
    )
```

The flag deliberately narrows the visibility semantics for `fetch_topic`: with `unread_only=True`, messages the viewer sent but is not a recipient of are excluded, because "unread" only has meaning for a recipient row. Documented in the docstring.

## Per-recipient correctness

The load-bearing case is "Agent A reads a message; Agent B is also a recipient and has not read it." Under `unread_only=True`, A must not see it; B must still see it. Test `test_fetch_inbox_unread_only_is_per_recipient_not_per_message` covers this. The SQL filter is on the JOIN's `read_ts` column scoped to the requesting agent's row — not on a message-level aggregate.

## Validation

- **6 new tests** in `tests/test_unread_only_filter.py`, all passing:
  - regression-safe default (omitted result set == `unread_only=False` result set)
  - basic filter on `fetch_inbox`
  - per-recipient (not per-message) semantics
  - AND-composition with `since_ts` and `topic` on `fetch_inbox`
  - basic filter on `fetch_topic`
  - AND-composition with `since_ts` on `fetch_topic`
- **No regressions** in the messaging surface (`test_messaging_semantics.py`, `test_message_delivery_regression.py`, `test_resources_mailbox.py`, `test_e2e_multi_agent_workflow.py`, adjacent broadcast/topic tests). 76 passed.
- **Three pre-existing failures** on baseline `upstream/main` (verified via `git stash` round-trip — fail with my diff stashed): `tests/test_broadcast.py::test_fetch_topic_tool` (assertion mismatch — only 1 of 2 expected messages returned), `tests/test_attachments_extended.py::test_attachments_keep_originals_and_manifest` (path-traversal config), `tests/test_concurrency_agents.py::TestRaceConditions::test_simultaneous_agent_registration_same_name` (concurrency flake). Happy to file as separate issues if you'd like — they're not in this PR's scope.

## Out of scope

- `fetch_inbox_product` (the cross-project variant) is not modified. Easy follow-up if you'd like the same filter there; I kept this diff focused on the two surfaces with the largest token-burn impact.
- The existing `resource://views/urgent-unread/{agent}` resource computes "unread" via an N+1 per-message query; not touched here. The new SQL filter would let it become a single-statement query in a follow-up.

## Notes

- One commit, conventional `feat(fetch):` prefix.
- Branch is rebased on current `upstream/main` (`9e5186b`).
- CHANGELOG entry under Unreleased / Messaging and Coordination.
- README updated in two places (the inline tip on line 1665 and the tool signature table near line 2292). `fetch_topic` is not currently in the README signature table; I did not add it (out of scope).