### PR TITLE
fix: clean default commit messages for sent messages (#156)

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -1650,7 +1650,24 @@ def _render_commit_panel(
     result_payload: dict[str, Any],
     created_iso: Optional[str],
 ) -> str | None:
-    """Create the Rich panel text used for Git commit messages."""
+    """
+    Optionally render a verbose Rich panel for the git commit message body.
+
+    Disabled by default since v2.13.1: the rendered panel includes ASCII-art
+    box-drawing characters that pollute `git log --oneline` and `git log`
+    output, making the audit log unreadable. The default
+    `_build_send_message_commit_message` path in `storage.py` produces a clean
+    `mail: <sender> -> <recipients> | <subject>` subject + structured body.
+
+    To re-enable verbose panels in commit messages (matches pre-v2.13.1
+    behavior), set `MCP_AGENT_MAIL_VERBOSE_COMMIT_MESSAGES=1` in the
+    environment. Console rich-logger output (TOOLS_LOG_ENABLED) is unaffected
+    and continues to display panels at the configured level.
+
+    See: https://github.com/Dicklesworthstone/mcp_agent_mail/issues/156
+    """
+    if os.environ.get("MCP_AGENT_MAIL_VERBOSE_COMMIT_MESSAGES", "").lower() not in ("1", "true", "yes"):
+        return None
     try:
         panel_ctx = rich_logger.ToolCallContext(
             tool_name=tool_name,


### PR DESCRIPTION
## Summary

Closes #156.

`send_message` currently writes git commits whose message body is the full ASCII-art rich-logger panel (with `╔══...╗` borders, emojis, and the entire result JSON). This makes `git log --oneline` and `git log` unreadable for any project where messages flow through. Only `send_message` commits are affected — `file_reservation:` and `agent: profile` commits are already clean.

This PR disables panel rendering for git commit messages by default. The existing default path in `storage.py` (`commit_subject = f"mail: {sender} -> {', '.join(recipients)} | {message.get('subject', '')}"` plus a structured 6-line body) takes over and produces a clean commit message.

## Behavior

**Before:**

```
$ git log --oneline
e42bc57 file_reservation: paul-spark src/main.py
a8b7183 ╔═════════════════════════ ✅ MCP TOOL CALL COMPLETED ═════════════════════════╗ ║                                                                              ║ ║  ══════════════════════════════════════════════════════════════════════════  ║ ║                      ⚡ MCP Tool Call Summary                                ║ ║  ╔═════════════════╤═════════════════════════════════════════════╗
fe96b13 file_reservation: willard-spark src/main.py
```

**After:**

```
$ git log --oneline
e42bc57 file_reservation: paul-spark src/main.py
a8b7183 mail: paul-spark -> willard-spark | Spark deploy E2E test
fe96b13 file_reservation: willard-spark src/main.py
```

## Backward compat

Set `MCP_AGENT_MAIL_VERBOSE_COMMIT_MESSAGES=1` to restore pre-change behavior. Console rich-logger output (`TOOLS_LOG_ENABLED`) is unaffected — panels still display in stdout/journal at the configured level.

## Test plan

- [x] Code parses + imports cleanly (`python3 -c 'import mcp_agent_mail.app'`)
- [ ] Run `make serve-http` with `TOOLS_LOG_ENABLED=true` — verify panels still appear in stdout
- [ ] Send a message — verify git commit subject is `mail: <sender> -> <recipients> | <subject>`
- [ ] Send another message with `MCP_AGENT_MAIL_VERBOSE_COMMIT_MESSAGES=1` — verify panel restored

I deployed mcp_agent_mail as the substrate for an inter-agent coordination workflow ([writeup with full deployment recipe](https://github.com/laulpogan/inter-agent-deaddrop)) and hit this immediately. Project's been great otherwise — token-based identity model, file-lease semantics, FTS5 search all worked first-try after wiring. Happy to revise this patch if you'd prefer different defaults (e.g., a separate config flag in `.env` instead of an env var).