### PR TITLE
fix(send_message): skip role-name heuristic for registered recipients

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -6911,7 +6911,13 @@ def build_mcp_server() -> FastMCP:
                 data={"argument": "to", "received_type": type(to).__name__},
             )
 
-        # Check for common recipient mistakes and provide helpful guidance
+        # Check for common recipient mistakes and provide helpful guidance.
+        # IMPORTANT: roster-check BEFORE the role-name heuristic (bead OneTUI-xlv3).
+        # The heuristic in _detect_agent_name_mistake rejects names with descriptive
+        # suffixes (e.g. "b-agent", "mailbox-epic-integrator"), but those handles
+        # are legitimate explicit identities once registered. If a recipient is
+        # already in the project roster we trust the roster and skip the heuristic;
+        # the existing recipient-existence checks further down still run.
         for recipient in to:
             if not isinstance(recipient, str):
                 raise ToolExecutionError(
@@ -6920,6 +6926,12 @@ def build_mcp_server() -> FastMCP:
                     recoverable=True,
                     data={"argument": "to", "invalid_item": repr(recipient)},
                 )
+            # Roster-first: if this name resolves to an agent in the current
+            # project, do not run the descriptive-name heuristic. Keep the
+            # heuristic active for unregistered names (typo guard).
+            roster_hit = await _find_agent_optional(project, recipient)
+            if roster_hit is not None:
+                continue
             mistake = _detect_agent_name_mistake(recipient)
             if mistake:
                 raise ToolExecutionError(

--- a/tests/test_agent_name_validation.py
+++ b/tests/test_agent_name_validation.py
@@ -678,3 +678,132 @@ class TestAgentNameEdgeCases:
         namespace_size = num_adjectives * num_nouns
         # Should have at least 4000 combinations (62 x 69 = 4278 per the comment)
         assert namespace_size >= 4000, f"Namespace too small: {namespace_size}"
+
+
+# ============================================================================
+# Regression: bead OneTUI-xlv3 — roster-check BEFORE role-name heuristic
+# in send_message. Registered explicit-IDs that happen to match descriptive
+# suffixes (e.g. "b-agent", "mailbox-epic-integrator") must NOT be rejected
+# as "descriptive role name" once they exist on the project roster.
+# ============================================================================
+
+
+def test_helper_still_flags_role_ish_handle_unchanged():
+    """The helper itself must remain a positive flag for role-ish handles.
+
+    The fix lives in send_message (roster check before the heuristic),
+    NOT in the helper. The helper's behaviour must not regress: an
+    unregistered ``b-agent`` shape is still a 'descriptive name' candidate.
+    """
+    from mcp_agent_mail.app import _detect_agent_name_mistake
+
+    result = _detect_agent_name_mistake("b-agent")
+    assert result is not None, "_detect_agent_name_mistake('b-agent') must still flag the shape"
+    assert result[0] == "DESCRIPTIVE_NAME"
+
+
+@pytest.mark.asyncio
+async def test_send_message_accepts_registered_role_ish_recipient(isolated_env):
+    """send_message must succeed when the recipient is registered, even
+    if its name shape matches the descriptive-role-name heuristic.
+
+    Regression for the bug confirmed at app.py:6923 — the heuristic ran
+    before the project roster lookup, so legitimate handles like
+    ``b-agent`` (registered via OneTUI per-agent worktrees) were rejected.
+    """
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "/test/xlv3-roster"})
+
+        # Register sender (auto-name)
+        sender_result = await client.call_tool(
+            "register_agent",
+            {
+                "project_key": "/test/xlv3-roster",
+                "program": "test",
+                "model": "test",
+            },
+        )
+        sender_name = sender_result.data["name"]
+
+        # Register a recipient whose explicit identity matches the
+        # descriptive-name heuristic ("agent" suffix).
+        recipient_result = await client.call_tool(
+            "register_agent",
+            {
+                "project_key": "/test/xlv3-roster",
+                "program": "test",
+                "model": "test",
+                "name": "b-agent",
+            },
+        )
+        recipient_name = recipient_result.data["name"]
+        assert recipient_name == "b-agent", (
+            "register_agent should accept 'b-agent' as an explicit identity; "
+            f"got: {recipient_name!r}"
+        )
+
+        # Send_message must NOT reject this with DESCRIPTIVE_NAME — the
+        # recipient is on the project roster.
+        result = await client.call_tool(
+            "send_message",
+            {
+                "project_key": "/test/xlv3-roster",
+                "sender_name": sender_name,
+                "to": ["b-agent"],
+                "subject": "xlv3 roundtrip",
+                "body_md": "Roster-check should win over the role-name heuristic.",
+            },
+        )
+
+        assert result.data["count"] == 1
+        deliveries = result.data["deliveries"]
+        assert len(deliveries) == 1
+        # Confirm the message persisted with a row id.
+        payload = deliveries[0].get("payload", {})
+        assert payload.get("id"), "delivered message must have a persisted id"
+
+
+@pytest.mark.asyncio
+async def test_send_message_unregistered_role_ish_still_rejected(isolated_env):
+    """The typo-guard half of the heuristic must STILL fire for unregistered
+    recipients that match the descriptive-name shape.
+
+    This is the safety net the heuristic exists for: an agent that mistypes
+    or invents a role-shaped name (with no matching roster entry) should
+    get the helpful DESCRIPTIVE_NAME error instead of a generic 'not
+    registered' deep in the recipient resolver.
+    """
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool(
+            "ensure_project", {"human_key": "/test/xlv3-unregistered"}
+        )
+
+        sender_result = await client.call_tool(
+            "register_agent",
+            {
+                "project_key": "/test/xlv3-unregistered",
+                "program": "test",
+                "model": "test",
+            },
+        )
+        sender_name = sender_result.data["name"]
+
+        with pytest.raises(Exception) as exc_info:
+            await client.call_tool(
+                "send_message",
+                {
+                    "project_key": "/test/xlv3-unregistered",
+                    "sender_name": sender_name,
+                    "to": ["unknown-agent"],  # not registered + role-ish shape
+                    "subject": "Should fail",
+                    "body_md": "Heuristic must still guard typos.",
+                },
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert "descriptive" in error_msg, (
+            "Unregistered role-shaped recipient must still hit the "
+            f"DESCRIPTIVE_NAME guard; got: {error_msg!r}"
+        )

--- a/tests/test_mistake_detection.py
+++ b/tests/test_mistake_detection.py
@@ -227,3 +227,37 @@ class TestDetectSuspiciousFileReservation:
         result = _detect_suspicious_file_reservation("//some/pattern")
         # Should not trigger absolute path warning
         assert result is None or "absolute" not in result.lower()
+
+
+# ============================================================================
+# Regression: bead OneTUI-xlv3 — helper behaviour is unchanged.
+# The bug fix lives in send_message (roster-first lookup before the
+# heuristic). The helper itself must still flag role-ish handles, so the
+# unregistered-typo guard keeps working.
+# ============================================================================
+
+
+class TestRosterFirstHelperUnchanged:
+    """The helper keeps its descriptive-name behaviour after the xlv3 fix."""
+
+    def test_b_agent_still_flagged(self):
+        """Bare 'b-agent' shape should still be flagged by the helper.
+
+        send_message now SKIPS the helper for registered recipients, but the
+        helper itself remains a typo guard for unregistered names.
+        """
+        result = _detect_agent_name_mistake("b-agent")
+        assert result is not None
+        assert result[0] == "DESCRIPTIVE_NAME"
+
+    def test_unknown_agent_still_flagged(self):
+        """Hyphenated 'unknown-agent' shape stays a heuristic hit."""
+        result = _detect_agent_name_mistake("unknown-agent")
+        assert result is not None
+        assert result[0] == "DESCRIPTIVE_NAME"
+
+    def test_mailbox_epic_integrator_still_flagged(self):
+        """Long role-ish handles seen in OneTUI agent worktrees stay flagged."""
+        result = _detect_agent_name_mistake("mailbox-epic-integrator")
+        assert result is not None
+        assert result[0] == "DESCRIPTIVE_NAME"


### PR DESCRIPTION
## Summary
- `send_message` now looks up the recipient in the project roster via the existing `_find_agent_optional` helper BEFORE running `_detect_agent_name_mistake`. Registered names skip the heuristic; unregistered names still get the typo guard.
- Closes a long-standing usability gap where role-ish but fully-registered handles (`b-agent`, `executor-onetui-X`, `mailbox-epic-integrator`, etc.) were rejected with a misleading "looks like a descriptive role name" error even though they existed on the server.
- `register_agent` is intentionally untouched — its existing-identity path is auth/session-binding, owned by a separate change.

## Why
Confirmed reproducibly during a cross-CLI mailbox bridge experiment on 2026-05-10:
- `b-agent` registered as id 192.
- `send_message(to=["b-agent"], …)` → 400 "descriptive role name".
- Heuristic at \`app.py:6923\` runs before the recipient-existence check at \`app.py:7782\`.

Re-ordering eliminates the rejection for any recipient already in the project roster.

## Test plan
- [x] Run touched test files: \`uv run pytest tests/test_agent_name_validation.py tests/test_mistake_detection.py -x --no-cov\` — 71 passed in 34.03s.
- [x] Helper still flags unregistered role-ish handles (typo guard preserved).
- [x] \`send_message\` to a registered \`b-agent\` succeeds end-to-end.
- [x] Unregistered \`unknown-agent\` still rejected with DESCRIPTIVE_NAME.
- [x] No changes to \`register_agent\` / \`create_agent_identity\`.

Pre-existing \`test_broadcast.py::test_fetch_topic_tool\` failure is unrelated to this change (fails on clean HEAD).