### PR TITLE
bd-fhm64: surface orphaned file reservations

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -1214,7 +1214,7 @@ def _require_project_resource_param(project: Optional[str], *, resource_name: st
 @dataclass(slots=True)
 class FileReservationStatus:
     reservation: FileReservation
-    agent: Agent
+    agent: Agent | None
     stale: bool
     stale_reasons: list[str]
     last_agent_activity: Optional[datetime]
@@ -3751,7 +3751,7 @@ async def _collect_file_reservation_statuses(
     async with get_session() as session:
         stmt = (
             select(FileReservation, Agent)
-            .join(Agent, cast(Any, FileReservation.agent_id) == Agent.id)
+            .outerjoin(Agent, cast(Any, FileReservation.agent_id) == Agent.id)
             .where(FileReservation.project_id == project.id)
             .order_by(asc(FileReservation.created_ts))
         )
@@ -3761,7 +3761,7 @@ async def _collect_file_reservation_statuses(
         rows = result.all()
         if not rows:
             return []
-        agent_ids = [agent.id for _, agent in rows if agent.id is not None]
+        agent_ids = [agent.id for _, agent in rows if agent is not None and agent.id is not None]
         send_map: dict[int, Optional[datetime]] = {}
         ack_map: dict[int, Optional[datetime]] = {}
         read_map: dict[int, Optional[datetime]] = {}
@@ -3804,10 +3804,13 @@ async def _collect_file_reservation_statuses(
     statuses: list[FileReservationStatus] = []
     try:
         for reservation, agent in rows:
-            agent_id = agent.id or -1
-            agent_last_active = _ensure_utc(agent.last_active_ts)
-            last_mail = _max_datetime(send_map.get(agent_id), ack_map.get(agent_id), read_map.get(agent_id))
-
+            agent_id = agent.id if agent is not None else None
+            agent_last_active = _ensure_utc(agent.last_active_ts) if agent is not None else None
+            last_mail = (
+                _max_datetime(send_map.get(agent_id), ack_map.get(agent_id), read_map.get(agent_id))
+                if agent_id is not None
+                else None
+            )
             matches: list[Path] = []
             fs_activity: Optional[datetime] = None
             git_activity: Optional[datetime] = None
@@ -3827,18 +3830,23 @@ async def _collect_file_reservation_statuses(
 
             stale = bool(
                 reservation.released_ts is None
-                and agent_inactive
-                and not (recent_mail or recent_fs or recent_git)
+                and (agent is None or (agent_inactive and not (recent_mail or recent_fs or recent_git)))
             )
             reasons: list[str] = []
-            if agent_inactive:
+            if agent is None:
+                if reservation.agent_id is None:
+                    reasons.append("agent_missing")
+                else:
+                    reasons.append("agent_unresolved")
+            elif agent_inactive:
                 reasons.append(f"agent_inactive>{inactivity_seconds}s")
             else:
                 reasons.append("agent_recently_active")
-            if recent_mail:
-                reasons.append("mail_activity_recent")
-            else:
-                reasons.append(f"no_recent_mail_activity>{activity_grace}s")
+            if agent is not None:
+                if recent_mail:
+                    reasons.append("mail_activity_recent")
+                else:
+                    reasons.append(f"no_recent_mail_activity>{activity_grace}s")
             if matches:
                 if recent_fs:
                     reasons.append("filesystem_activity_recent")
@@ -3975,7 +3983,11 @@ async def _expire_stale_file_reservations(
             )
             await session.commit()
     statuses = await _collect_file_reservation_statuses(project, include_released=False, now=now)
-    stale_statuses = [status for status in statuses if status.stale and status.reservation.id is not None]
+    stale_statuses = [
+        status
+        for status in statuses
+        if status.agent is not None and status.stale and status.reservation.id is not None
+    ]
     stale_ids = [cast(int, status.reservation.id) for status in stale_statuses]
     if stale_ids:
         async with get_immediate_session() as session:
@@ -4007,6 +4019,8 @@ async def _expire_stale_file_reservations(
         released_pairs.append((reservation, agent))
     for status in stale_statuses:
         if status.reservation.id is None:
+            continue
+        if status.agent is None:
             continue
         if status.reservation.id in seen_ids:
             continue
@@ -10866,10 +10880,21 @@ def build_mcp_server() -> FastMCP:
         )
         if project.id is None:
             raise ValueError("Project must have an id before reserving file paths.")
+        if agent.id is None:
+            raise ValueError("Agent must have an id before reserving file paths.")
+        agent_touch_ts = _naive_utc()
+        async with get_session() as session:
+            await session.execute(
+                update(Agent)
+                .where(cast(Any, Agent.id) == agent.id)
+                .values(last_active_ts=agent_touch_ts)
+            )
+            await session.commit()
+        agent.last_active_ts = agent_touch_ts
         stale_auto_releases = await _expire_stale_file_reservations(project.id)
         if stale_auto_releases:
             summary = ", ".join(
-                f"{status.agent.name}:{status.reservation.path_pattern}"
+                f"{status.agent.name if status.agent is not None else '<unresolved>'}:{status.reservation.path_pattern}"
                 for status in stale_auto_releases[:5]
             )
             extra = f" ({summary})" if summary else ""
@@ -11464,7 +11489,7 @@ def build_mcp_server() -> FastMCP:
         stale_auto_releases = await _expire_stale_file_reservations(project.id)
         if stale_auto_releases:
             summary = ", ".join(
-                f"{status.agent.name}:{status.reservation.path_pattern}"
+                f"{status.agent.name if status.agent is not None else '<unresolved>'}:{status.reservation.path_pattern}"
                 for status in stale_auto_releases[:5]
             )
             extra = f" ({summary})" if summary else ""
@@ -13126,7 +13151,8 @@ def build_mcp_server() -> FastMCP:
             payload.append(
                 {
                     "id": reservation.id,
-                    "agent": status.agent.name,
+                    "agent": status.agent.name if status.agent is not None else None,
+                    "agent_id": reservation.agent_id,
                     "path_pattern": reservation.path_pattern,
                     "exclusive": reservation.exclusive,
                     "reason": reservation.reason,

--- a/src/mcp_agent_mail/models.py
+++ b/src/mcp_agent_mail/models.py
@@ -119,7 +119,7 @@ class FileReservation(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     project_id: int = Field(foreign_key="projects.id", index=True)
-    agent_id: int = Field(foreign_key="agents.id", index=True)
+    agent_id: Optional[int] = Field(default=None, foreign_key="agents.id", index=True)
     path_pattern: str = Field(max_length=512)
     exclusive: bool = Field(default=True)
     reason: str = Field(default="", max_length=512)

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -21,13 +21,17 @@ Reference: mcp_agent_mail-hqk
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote
 
 import pytest
 from fastmcp import Client
+from sqlalchemy import select, update
 
 from mcp_agent_mail.app import build_mcp_server
+from mcp_agent_mail.db import get_session
+from mcp_agent_mail.models import Agent, FileReservation, Project
 
 # ============================================================================
 # Helper: Parse JSON from resource blocks
@@ -703,6 +707,49 @@ async def test_file_reservations_resource_returns_reservations(isolated_env):
 
 
 @pytest.mark.asyncio
+async def test_file_reservation_paths_refreshes_holder_activity_before_resource_listing(isolated_env):
+    """A newly issued reservation should not be auto-released because the holder was previously inactive."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "/fileactivity"})
+
+        agent_result = await client.call_tool(
+            "register_agent",
+            {"project_key": "FileActivity", "program": "test", "model": "test"},
+        )
+        agent_name = agent_result.data["name"]
+        old_activity = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
+
+        async with get_session() as session:
+            await session.execute(
+                update(Agent)
+                .where(Agent.name == agent_name)
+                .values(last_active_ts=old_activity)
+            )
+            await session.commit()
+
+        await client.call_tool(
+            "file_reservation_paths",
+            {
+                "project_key": "FileActivity",
+                "agent_name": agent_name,
+                "paths": ["fresh.py"],
+                "exclusive": True,
+                "reason": "fresh reservation",
+            },
+        )
+
+        blocks = await client.read_resource("resource://file_reservations/fileactivity")
+        data = parse_resource_json(blocks)
+
+        assert data is not None
+        reservation = next((item for item in data if item["path_pattern"] == "fresh.py"), None)
+        assert reservation is not None, "Fresh reservation should stay active after listing"
+        assert reservation["agent"] == agent_name
+        assert reservation["stale"] is False
+
+
+@pytest.mark.asyncio
 async def test_file_reservations_resource_active_only(isolated_env):
     """File reservations resource with active_only=true filters released."""
     server = build_mcp_server()
@@ -844,6 +891,41 @@ async def test_file_reservations_resource_includes_metadata(isolated_env):
         assert "created_ts" in reservation, "Should have created_ts"
         assert "expires_ts" in reservation, "Should have expires_ts"
         assert "stale" in reservation, "Should have stale flag"
+
+
+@pytest.mark.asyncio
+async def test_file_reservations_resource_surfaces_null_agent_reservation(isolated_env):
+    """Orphaned file reservations must not disappear from the resource listing."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "/fileorphan"})
+
+        async with get_session() as session:
+            project = (
+                await session.execute(select(Project).where(Project.slug == "fileorphan"))
+            ).scalar_one()
+            assert project.id is not None
+            reservation = FileReservation(
+                project_id=project.id,
+                agent_id=None,
+                path_pattern="orphaned.py",
+                exclusive=True,
+                reason="orphan fixture",
+                expires_ts=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1),
+            )
+            session.add(reservation)
+            await session.commit()
+
+        blocks = await client.read_resource("resource://file_reservations/fileorphan")
+        data = parse_resource_json(blocks)
+
+        assert data is not None
+        orphan = next((item for item in data if item["path_pattern"] == "orphaned.py"), None)
+        assert orphan is not None, "Orphaned reservation should be visible"
+        assert orphan["agent"] is None
+        assert orphan["agent_id"] is None
+        assert orphan["stale"] is True
+        assert "agent_missing" in orphan["stale_reasons"]
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- publishes local bd-fhm64 fix commit 237c8dc from the VPS worktree
- changes file reservation status collection so orphaned reservations are surfaced instead of dropped by an INNER JOIN
- adds regression coverage for orphaned file reservations

## Verification
- .venv/bin/python -m pytest tests/test_mcp_resources.py -q => 30 passed (recorded in bd-rmx4h evidence from local deployment)
- py_compile changed files passed (recorded in bd-rmx4h evidence)

## Publishing note
Direct push to Dicklesworthstone/mcp_agent_mail remains blocked for IvanWest33 with viewerPermission=READ, so this fork branch is the maintainer merge path for upstream main.