### PR TITLE
feat(file_reservation_paths): add warnings field for code-repo paths

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -11014,7 +11014,25 @@ def build_mcp_server() -> FastMCP:
             if payloads:
                 await write_file_reservation_records(archive, payloads)
         await ctx.info(f"Issued {len(granted)} file_reservations for '{agent.name}'. Conflicts: {len(conflicts)}")
-        return {"granted": granted, "conflicts": conflicts}
+        # Surface per-call enforcement mode so wrappers (e.g. ntm's CLI) can
+        # warn callers that code-repo paths are advisory-only. Server-side
+        # enforcement only covers mail-archive paths (see docstring); code
+        # repo paths are protected by the pre-commit guard, not the server.
+        # Without an explicit signal in the JSON response, downstream tools
+        # have no programmatic way to detect the advisory-only mode beyond
+        # parsing the docstring.
+        warnings_list: list[str] = []
+        advisory_only_paths = [p for p in paths if not _looks_like_archive_path(p)]
+        if advisory_only_paths:
+            warnings_list.append(
+                "enforcement_off_for_code_paths: "
+                f"{len(advisory_only_paths)} of {len(paths)} reserved paths are "
+                "code-repo paths; server-side exclusivity is advisory only. "
+                "Conflict reporting is best-effort and the pre-commit guard is the "
+                "authoritative gate. See the file_reservation_paths docstring for "
+                "the full enforcement policy."
+            )
+        return {"granted": granted, "conflicts": conflicts, "warnings": warnings_list}
 
     @mcp.tool(name="release_file_reservations")
     @_instrument_tool("release_file_reservations", cluster=CLUSTER_FILE_RESERVATIONS, capabilities={"file_reservations"}, project_arg="project_key", agent_arg="agent_name")

--- a/tests/test_resource_cleanup.py
+++ b/tests/test_resource_cleanup.py
@@ -259,3 +259,108 @@ async def test_file_reservation_release_works(isolated_env, tmp_path: Path):
             {"project_key": str(workspace), "agent_name": "BlueDog"},
         )
         assert res2.data.get("released", 0) > 0
+
+
+@pytest.mark.asyncio
+async def test_file_reservation_paths_warns_on_code_paths(isolated_env, tmp_path: Path):
+    """bd-unqoc: code-repo paths must surface an 'enforcement_off_for_code_paths'
+    warning in the file_reservation_paths response so wrappers (e.g. the ntm
+    CLI) can tell the caller that server-side exclusivity is advisory only
+    for code paths (mail-archive paths are enforced server-side; code paths
+    rely on the pre-commit guard)."""
+    from mcp_agent_mail.app import build_mcp_server
+
+    server = build_mcp_server()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    proc = await asyncio.create_subprocess_exec("git", "init", cwd=str(workspace))
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "config", "user.email", "test@example.com", cwd=str(workspace)
+    )
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "config", "user.name", "Test User", cwd=str(workspace)
+    )
+    await proc.wait()
+
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": str(workspace)})
+        reg = await client.call_tool(
+            "register_agent",
+            {
+                "project_key": str(workspace),
+                "program": "test-cli",
+                "model": "test-model",
+                "name": "WarnPath",
+            },
+        )
+        # Test harness may assign a different name (random allocation on
+        # name conflict); use whatever name was actually registered.
+        agent_name = (reg.data or {}).get("name") or "WarnPath"
+        result = await client.call_tool(
+            "file_reservation_paths",
+            {
+                "project_key": str(workspace),
+                "agent_name": agent_name,
+                "paths": ["src/foo.py"],
+                "ttl_seconds": 3600,
+            },
+        )
+        warnings_list = result.data.get("warnings") or []
+        assert any(
+            isinstance(w, str) and w.startswith("enforcement_off_for_code_paths")
+            for w in warnings_list
+        ), f"warnings missing enforcement_off_for_code_paths: {warnings_list!r}"
+
+
+@pytest.mark.asyncio
+async def test_file_reservation_paths_no_warning_for_archive_paths(
+    isolated_env, tmp_path: Path
+):
+    """bd-unqoc: archive paths (agents/, messages/, attachments/, ...) are
+    enforced server-side, so the warnings array MUST be empty when every
+    reserved path is an archive path."""
+    from mcp_agent_mail.app import build_mcp_server
+
+    server = build_mcp_server()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    proc = await asyncio.create_subprocess_exec("git", "init", cwd=str(workspace))
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "config", "user.email", "test@example.com", cwd=str(workspace)
+    )
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "config", "user.name", "Test User", cwd=str(workspace)
+    )
+    await proc.wait()
+
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": str(workspace)})
+        reg = await client.call_tool(
+            "register_agent",
+            {
+                "project_key": str(workspace),
+                "program": "test-cli",
+                "model": "test-model",
+                "name": "ArchivePath",
+            },
+        )
+        agent_name = (reg.data or {}).get("name") or "ArchivePath"
+        result = await client.call_tool(
+            "file_reservation_paths",
+            {
+                "project_key": str(workspace),
+                "agent_name": agent_name,
+                # All archive-prefix paths — agents/, messages/, attachments/
+                "paths": ["agents/x.json", "messages/y.json", "attachments/z.bin"],
+                "ttl_seconds": 3600,
+            },
+        )
+        warnings_list = result.data.get("warnings") or []
+        assert not any(
+            isinstance(w, str) and w.startswith("enforcement_off_for_code_paths")
+            for w in warnings_list
+        ), f"archive-only paths should not warn: {warnings_list!r}"


### PR DESCRIPTION
## What

Add a `warnings: list[str]` field to the `file_reservation_paths` MCP tool response. When one or more reserved paths are code-repo paths (not under any of the existing `_ARCHIVE_PATH_PREFIXES`), the response now carries:

```json
{
  "granted": [...],
  "conflicts": [...],
  "warnings": [
    "enforcement_off_for_code_paths: N of M reserved paths are code-repo paths; server-side exclusivity is advisory only. Conflict reporting is best-effort and the pre-commit guard is the authoritative gate. See the file_reservation_paths docstring for the full enforcement policy."
  ]
}
```

When every reserved path is an archive path, the warnings list is empty.

## Why

The tool's docstring already states:

> Server-side enforcement (if enabled) only checks reservations that target mail archive paths such as `agents/`, `messages/`, or `attachments/`; code repo enforcement is via the pre-commit guard

…but the response carries no programmatic signal of that advisory-only mode. Downstream wrappers (in our case the `ntm` Go CLI's `lock` subcommand) have no way to surface this to the operator beyond parsing the docstring, and silently print success-shaped output as if exclusivity were enforced. This led to a multi-agent collision incident in the consuming project where two panes reserved the same code path and both saw a successful grant.

## How

- Reuse the existing `_looks_like_archive_path` helper (no new classification logic).
- After granted/conflicts are accumulated and before the return, build `warnings_list` and include the `enforcement_off_for_code_paths` entry if any path falls outside `_ARCHIVE_PATH_PREFIXES`.
- No change to grant/conflict semantics. No change to the persisted reservation rows.

## Tests

Two new tests in `tests/test_resource_cleanup.py`:

- `test_file_reservation_paths_warns_on_code_paths` — single `src/foo.py` reservation must produce the warning.
- `test_file_reservation_paths_no_warning_for_archive_paths` — reservations under `agents/`, `messages/`, `attachments/` must NOT produce the warning.

Mutation round-trip (commenting out the `warnings_list.append` line) breaks the warns-on-code-paths test, confirming non-trivial coverage. Full file_reservation test set: 4/4 passing.

## Backward compatibility

The new field is additive. Existing clients that ignore unknown keys continue to work. No changes to grant/conflict shapes.

## Context (downstream)

This surfaces the gap documented in the consumer project as a multi-agent lock-visibility incident. Once this lands, the wrapper CLI can print the warning on `lock` output so operators see "Reserved 1 path(s) — advisory only on code paths" instead of treating the grant as enforced.