### PR TITLE
Allow Agent Mail access over Tailscale

### DIFF
--- a/scripts/run_server_with_token.sh
+++ b/scripts/run_server_with_token.sh
@@ -1,74 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AM_RUST_BIN="${HOME}/.local/bin/am"
-AM_RUST_ENV_FILE_DEFAULT="${HOME}/.config/mcp-agent-mail/config.env"
-AM_RUST_ENV_FILE="${AM_RUST_ENV_FILE:-$AM_RUST_ENV_FILE_DEFAULT}"
-if [ ! -f "$AM_RUST_ENV_FILE" ] && [ -f "${HOME}/.config/mcp-agent-mail/config.env" ]; then
-  AM_RUST_ENV_FILE="${HOME}/.config/mcp-agent-mail/config.env"
-fi
-if [ ! -f "$AM_RUST_ENV_FILE" ] && [ -f "${HOME}/.config/mcp-agent-mail/.env" ]; then
-  AM_RUST_ENV_FILE="${HOME}/.config/mcp-agent-mail/.env"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "${ROOT_DIR}/scripts/lib.sh" ]]; then
+  # shellcheck disable=SC1090
+  . "${ROOT_DIR}/scripts/lib.sh"
 fi
 
-trim_ascii_whitespace() {
-  local value="${1:-}"
-  value="${value#\"${value%%[![:space:]]*}\"}"
-  value="${value%\"${value##*[![:space:]]}\"}"
-  printf '%s\n' "$value"
-}
-
-load_env_key() {
-  local key="$1"
-  [ -f "$AM_RUST_ENV_FILE" ] || return 0
-
-  local raw
-  raw=$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=" "$AM_RUST_ENV_FILE" 2>/dev/null | tail -1 | sed -E "s/^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=[[:space:]]*//" || true)
-  [ -n "$raw" ] || return 0
-
-  raw=$(trim_ascii_whitespace "$raw")
-  local parsed="" quote="" prev="" char=""
-  local raw_len=${#raw}
-  local i=0
-  while [ "$i" -lt "$raw_len" ]; do
-    char="${raw:$i:1}"
-    if [ -n "$quote" ]; then
-      parsed="${parsed}${char}"
-      if [ "$char" = "$quote" ]; then
-        quote=""
-      fi
-    else
-      if [ "$char" = '"' ] || [ "$char" = "'" ]; then
-        quote="$char"
-        parsed="${parsed}${char}"
-      elif [ "$char" = "#" ]; then
-        if [ -z "$prev" ] || [[ "$prev" =~ [[:space:]] ]]; then
-          break
-        fi
-        parsed="${parsed}${char}"
-      else
-        parsed="${parsed}${char}"
-      fi
-    fi
-    prev="$char"
-    i=$((i + 1))
-  done
-
-  raw=$(trim_ascii_whitespace "$parsed")
-  raw="${raw%\"}"
-  raw="${raw#\"}"
-  raw="${raw%\'}"
-  raw="${raw#\'}"
-  export "${key}=${raw}"
-}
-
-for key in DATABASE_URL STORAGE_ROOT HTTP_HOST HTTP_PORT HTTP_PATH HTTP_BEARER_TOKEN TUI_ENABLED LLM_ENABLED LLM_DEFAULT_MODEL WORKTREES_ENABLED; do
-  load_env_key "$key"
-done
-
-if [ ! -x "$AM_RUST_BIN" ]; then
-  echo "mcp-agent-mail Rust CLI not found at $AM_RUST_BIN" >&2
-  exit 1
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]] && declare -F resolve_integration_bearer_token >/dev/null 2>&1; then
+  HTTP_BEARER_TOKEN="$(resolve_integration_bearer_token "${ROOT_DIR}")"
 fi
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
+  if [[ -f "${ROOT_DIR}/.env" ]]; then
+    HTTP_BEARER_TOKEN=$(grep -E '^HTTP_BEARER_TOKEN=' "${ROOT_DIR}/.env" 2>/dev/null | tail -n 1 | sed -E 's/^HTTP_BEARER_TOKEN=//') || true
+  fi
+fi
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]] && declare -F generate_bearer_token >/dev/null 2>&1; then
+  HTTP_BEARER_TOKEN="$(generate_bearer_token)"
+fi
+if [[ -z "${HTTP_BEARER_TOKEN:-}" ]]; then
+  if command -v openssl >/dev/null 2>&1; then
+    HTTP_BEARER_TOKEN="$(openssl rand -hex 32)"
+  elif command -v uv >/dev/null 2>&1; then
+    HTTP_BEARER_TOKEN="$(uv run python -c 'import secrets;print(secrets.token_hex(32))')"
+  else
+    HTTP_BEARER_TOKEN="$(date +%s)_$(hostname 2>/dev/null || echo host)"
+  fi
+fi
+export HTTP_BEARER_TOKEN
 
-exec "$AM_RUST_BIN" "$@"
+uv run python -m mcp_agent_mail.cli serve-http "$@"

--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -73,6 +73,7 @@ class HttpSettings:
     rbac_readonly_tools: list[str]
     # Dev convenience
     allow_localhost_unauthenticated: bool
+    allow_tailscale_unauthenticated: bool
 
 
 @dataclass(slots=True, frozen=True)
@@ -324,7 +325,7 @@ def _build_settings() -> Settings:
         return items
 
     http_settings = HttpSettings(
-        host=decouple_config("HTTP_HOST", default="127.0.0.1"),
+        host=decouple_config("HTTP_HOST", default="0.0.0.0"),
         port=_int(decouple_config("HTTP_PORT", default="8765"), default=8765),
         path=decouple_config("HTTP_PATH", default="/api/"),
         bearer_token=decouple_config("HTTP_BEARER_TOKEN", default="") or None,
@@ -356,6 +357,7 @@ def _build_settings() -> Settings:
             default="health_check,fetch_inbox,whois,search_messages,summarize_thread",
         ),
         allow_localhost_unauthenticated=_bool(decouple_config("HTTP_ALLOW_LOCALHOST_UNAUTHENTICATED", default="true"), default=True),
+        allow_tailscale_unauthenticated=_bool(decouple_config("HTTP_ALLOW_TAILSCALE_UNAUTHENTICATED", default="true"), default=True),
     )
 
     database_settings = DatabaseSettings(

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -8,6 +8,7 @@ import base64
 import contextlib
 import hmac
 import importlib
+import ipaddress
 import json
 import logging
 import re
@@ -577,11 +578,21 @@ def _configure_logging(settings: Settings) -> None:
     _LOGGING_CONFIGURED = True
 
 
+TAILSCALE_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
 class BearerAuthMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, token: str, allow_localhost: bool = False) -> None:
+    def __init__(
+        self,
+        app: FastAPI,
+        token: str,
+        allow_localhost: bool = False,
+        allow_tailscale: bool = False,
+    ) -> None:
         super().__init__(app)
         self._token = token
         self._allow_localhost = allow_localhost
+        self._allow_tailscale = allow_tailscale
 
     @staticmethod
     def _is_localhost(host: str) -> bool:
@@ -593,6 +604,16 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return True
         # IPv4-mapped IPv6 address (::ffff:127.0.0.1)
         return bool(host.lower().startswith("::ffff:") and host[7:] == "127.0.0.1")
+
+    @staticmethod
+    def _is_tailscale(host: str) -> bool:
+        """Check if host is in Tailscale's 100.64.0.0/10 address range."""
+        if not host:
+            return False
+        try:
+            return ipaddress.ip_address(host) in TAILSCALE_NETWORK
+        except ValueError:
+            return False
 
     @staticmethod
     def _has_forwarded_headers(request: Request) -> bool:
@@ -608,9 +629,10 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         if request.url.path.startswith("/health/") or request.url.path == "/api/health":
             return await call_next(request)
-        if _localhost_bypass_allowed(
+        if _unauthenticated_bypass_allowed(
             request,
             allow_localhost=self._allow_localhost,
+            allow_tailscale=self._allow_tailscale,
         ):
             return await call_next(request)
         auth_header = request.headers.get("Authorization", "")
@@ -631,6 +653,35 @@ def _localhost_bypass_allowed(request: Request, *, allow_localhost: bool) -> boo
         client_host = ""
     return BearerAuthMiddleware._is_localhost(client_host) and not BearerAuthMiddleware._has_forwarded_headers(
         request
+    )
+
+
+def _tailscale_bypass_allowed(request: Request, *, allow_tailscale: bool) -> bool:
+    """Return whether this request qualifies for Tailscale auth bypass."""
+    if not allow_tailscale:
+        return False
+    try:
+        client_host = request.client.host if request.client else ""
+    except Exception:
+        client_host = ""
+    return BearerAuthMiddleware._is_tailscale(client_host) and not BearerAuthMiddleware._has_forwarded_headers(
+        request
+    )
+
+
+def _unauthenticated_bypass_allowed(
+    request: Request,
+    *,
+    allow_localhost: bool,
+    allow_tailscale: bool,
+) -> bool:
+    """Return whether this request may skip bearer auth."""
+    return _localhost_bypass_allowed(
+        request,
+        allow_localhost=allow_localhost,
+    ) or _tailscale_bypass_allowed(
+        request,
+        allow_tailscale=allow_tailscale,
     )
 
 
@@ -855,19 +906,21 @@ class SecurityAndRateLimitMiddleware(BaseHTTPMiddleware):
                 roles = {self._default_role}
         else:
             roles = {self._default_role}
-            # Elevate localhost to writer when unauthenticated localhost is allowed
-            if _localhost_bypass_allowed(
+            # Elevate trusted unauthenticated local/Tailscale clients to writer.
+            if _unauthenticated_bypass_allowed(
                 request,
                 allow_localhost=bool(getattr(self.settings.http, "allow_localhost_unauthenticated", False)),
+                allow_tailscale=bool(getattr(self.settings.http, "allow_tailscale_unauthenticated", False)),
             ):
                 roles.add("writer")
 
-        # RBAC enforcement (skip for localhost when allowed)
-        is_local_ok = _localhost_bypass_allowed(
+        # RBAC enforcement (skip for trusted unauthenticated clients when allowed)
+        is_trusted_unauthenticated = _unauthenticated_bypass_allowed(
             request,
             allow_localhost=bool(getattr(self.settings.http, "allow_localhost_unauthenticated", False)),
+            allow_tailscale=bool(getattr(self.settings.http, "allow_tailscale_unauthenticated", False)),
         )
-        if self._rbac_enabled and not is_local_ok and kind in {"tools", "resources"}:
+        if self._rbac_enabled and not is_trusted_unauthenticated and kind in {"tools", "resources"}:
             is_reader = bool(roles & self._reader_roles)
             is_writer = bool(roles & self._writer_roles) or (not roles)
             if kind == "resources":
@@ -1367,6 +1420,7 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
             BearerAuthMiddleware,
             token=settings.http.bearer_token,
             allow_localhost=bool(getattr(settings.http, "allow_localhost_unauthenticated", False)),
+            allow_tailscale=bool(getattr(settings.http, "allow_tailscale_unauthenticated", False)),
         )
 
     # Optional CORS
@@ -1574,11 +1628,12 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
                     except Exception:
                         response_body = {}
 
-            # If localhost and allow_localhost_unauthenticated, synthesize Authorization header automatically
+            # If trusted unauthenticated access is enabled, synthesize Authorization automatically.
             scope = dict(request.scope)
-            if _localhost_bypass_allowed(
+            if _unauthenticated_bypass_allowed(
                 request,
                 allow_localhost=bool(settings.http.allow_localhost_unauthenticated),
+                allow_tailscale=bool(getattr(settings.http, "allow_tailscale_unauthenticated", False)),
             ):
                 scope_headers = list(scope.get("headers") or [])
                 has_auth = any(k.lower() == b"authorization" for k, _ in scope_headers)

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -230,6 +230,46 @@ class TestLocalhostBypass:
             assert response.status_code == 200
 
 
+class TestTailscaleBypass:
+    """Test Tailscale authentication bypass behavior."""
+
+    @pytest.mark.asyncio
+    async def test_tailscale_bypass_enabled(self, isolated_env, monkeypatch):
+        """With Tailscale bypass enabled, no auth is required for Tailscale clients."""
+        monkeypatch.setenv("HTTP_BEARER_TOKEN", "secret-token")
+        monkeypatch.setenv("HTTP_ALLOW_LOCALHOST_UNAUTHENTICATED", "false")
+        monkeypatch.setenv("HTTP_ALLOW_TAILSCALE_UNAUTHENTICATED", "true")
+        with contextlib.suppress(Exception):
+            _config.clear_settings_cache()
+
+        settings = _config.get_settings()
+        server = build_mcp_server()
+        app = build_http_app(settings, server)
+
+        transport = ASGITransport(app=app, client=("100.84.193.107", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/mail")
+            assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_lan_client_still_requires_auth(self, isolated_env, monkeypatch):
+        """A non-Tailscale remote client still requires bearer auth."""
+        monkeypatch.setenv("HTTP_BEARER_TOKEN", "secret-token")
+        monkeypatch.setenv("HTTP_ALLOW_LOCALHOST_UNAUTHENTICATED", "false")
+        monkeypatch.setenv("HTTP_ALLOW_TAILSCALE_UNAUTHENTICATED", "true")
+        with contextlib.suppress(Exception):
+            _config.clear_settings_cache()
+
+        settings = _config.get_settings()
+        server = build_mcp_server()
+        app = build_http_app(settings, server)
+
+        transport = ASGITransport(app=app, client=("192.168.1.10", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/mail")
+            assert response.status_code == 401
+
+
 # =============================================================================
 # Test: CORS Preflight Bypass
 # =============================================================================


### PR DESCRIPTION
## Summary
- run the Python Agent Mail launcher with resolved bearer tokens
- default HTTP host binding to all interfaces
- allow unauthenticated localhost and Tailscale clients while keeping bearer auth for other remote clients
- add regression coverage for Tailscale bypass vs normal LAN clients

## Verification
- bash -n scripts/run_server_with_token.sh
- uv run python -m ruff check src/mcp_agent_mail/config.py src/mcp_agent_mail/http.py tests/test_http_auth.py
- uv run python -m compileall -q src/mcp_agent_mail/config.py src/mcp_agent_mail/http.py tests/test_http_auth.py
- uv run python -m pytest tests/test_http_auth.py::TestBearerTokenAuth tests/test_http_auth.py::TestLocalhostBypass tests/test_http_auth.py::TestTailscaleBypass -q