### PR TITLE
Bound Agent Mail lock inventory scans

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -74,7 +74,7 @@ from .storage import (
     archive_write_lock,
     clear_notification_signal,
     clear_repo_cache,
-    collect_lock_status,
+    collect_lock_status_async,
     emit_notification_signal,
     ensure_archive,
     heal_archive_locks,
@@ -2729,23 +2729,26 @@ def _canonical_project_pair(a_id: int, b_id: int) -> tuple[int, int]:
 
 
 @asynccontextmanager
-async def _archive_write_lock(archive: ProjectArchive, *, timeout_seconds: float = 60.0) -> AsyncIterator[None]:
+async def _archive_write_lock(archive: ProjectArchive, *, timeout_seconds: float = 10.0) -> AsyncIterator[None]:
     try:
         async with archive_write_lock(archive, timeout_seconds=timeout_seconds):
             yield
     except TimeoutError as exc:
+        lock_status = await collect_lock_status_async(get_settings(), project_slug=archive.slug)
         raise ToolExecutionError(
             "ARCHIVE_LOCK_TIMEOUT",
             (
                 f"Archive lock busy for project '{archive.slug}' at '{archive.lock_path}'. "
                 f"Timed out after {timeout_seconds:.1f}s. "
-                "Inspect running agents or call collect_lock_status to clear stale locks."
+                "Inspect running agents or run `am doctor check --json` before repair."
             ),
             recoverable=True,
             data={
                 "project_slug": archive.slug,
                 "lock_path": str(archive.lock_path),
                 "timeout_seconds": timeout_seconds,
+                "reason_code": "archive_lock_timeout",
+                "lock_status": lock_status,
             },
         ) from exc
 
@@ -4994,9 +4997,9 @@ def build_mcp_server() -> FastMCP:
         if isinstance(cached, str):
             return cached
         orphan_key = f"orphan:{uuid.uuid4()}"
-        # ctx refuses attribute assignment; multi-lookup consistency
-        # degrades to "best effort" but a single lookup still works.
-        with suppress(Exception):
+        with contextlib.suppress(Exception):
+            # ctx refuses attribute assignment; multi-lookup consistency
+            # degrades to "best effort" but a single lookup still works.
             ctx._mcp_agent_mail_orphan_key = orphan_key  # type: ignore[attr-defined]
         return orphan_key
 
@@ -13124,11 +13127,11 @@ def build_mcp_server() -> FastMCP:
     def tooling_metrics_resource(format: Optional[str] = None) -> dict[str, Any]:
         return _read_tooling_metrics_resource(format)
 
-    def _read_tooling_locks_resource(format: Optional[str] = None) -> dict[str, Any]:
+    async def _read_tooling_locks_resource(format: Optional[str] = None) -> dict[str, Any]:
         """Return lock metadata from the shared archive storage."""
 
         settings_local = get_settings()
-        payload = collect_lock_status(settings_local)
+        payload = await collect_lock_status_async(settings_local)
         return _apply_resource_output_format(
             payload,
             settings=settings,
@@ -13137,12 +13140,12 @@ def build_mcp_server() -> FastMCP:
         )
 
     @mcp.resource("resource://tooling/locks", mime_type="application/json")
-    def tooling_locks_resource_exact() -> dict[str, Any]:
-        return _read_tooling_locks_resource()
+    async def tooling_locks_resource_exact() -> dict[str, Any]:
+        return await _read_tooling_locks_resource()
 
     @mcp.resource("resource://tooling/locks{?format}", mime_type="application/json")
-    def tooling_locks_resource(format: Optional[str] = None) -> dict[str, Any]:
-        return _read_tooling_locks_resource(format)
+    async def tooling_locks_resource(format: Optional[str] = None) -> dict[str, Any]:
+        return await _read_tooling_locks_resource(format)
 
     @mcp.resource("resource://tooling/capabilities/{agent}{?project,format}", mime_type="application/json")
     def tooling_capabilities_resource(

--- a/src/mcp_agent_mail/cli.py
+++ b/src/mcp_agent_mail/cli.py
@@ -5474,23 +5474,49 @@ def doctor_check(
 
         lock_status = collect_lock_status(settings, project_slug=project_slug)
         stale_locks = [
-            cast(str, lock.get("path"))
+            lock
             for lock in lock_status.get("locks", [])
-            if lock.get("stale_suspected") and isinstance(lock.get("path"), str)
+            if isinstance(lock, dict)
+            and lock.get("stale_suspected")
+            and isinstance(lock.get("path"), str)
+        ]
+        stale_details = [
+            json.dumps(
+                {
+                    "path": lock.get("path"),
+                    "category": lock.get("category"),
+                    "reason_code": lock.get("reason_code"),
+                    "owner_pid": lock.get("owner_pid"),
+                    "owner_alive": lock.get("owner_alive"),
+                    "age_seconds": lock.get("age_seconds"),
+                    "safe_remediation": lock.get("safe_remediation"),
+                },
+                sort_keys=True,
+            )
+            for lock in stale_locks
         ]
         if stale_locks:
             results.append(DiagnosticResult(
                 name="Locks",
                 status="warning",
                 message=f"{len(stale_locks)} stale lock(s) found",
-                details=[str(lock) for lock in stale_locks],
+                details=stale_details,
                 repair_available=True,
+            ))
+        elif lock_status.get("summary", {}).get("scan_timed_out") or lock_status.get("summary", {}).get("scan_truncated"):
+            results.append(DiagnosticResult(
+                name="Locks",
+                status="warning",
+                message="Lock inventory scan did not complete within bounds",
+                details=[json.dumps(lock_status.get("scan", {}), sort_keys=True)],
+                repair_available=False,
             ))
         else:
             results.append(DiagnosticResult(
                 name="Locks",
                 status="ok",
                 message="No stale locks found",
+                details=[json.dumps(lock_status.get("scan", {}), sort_keys=True)],
             ))
 
         # Check 2: Database integrity
@@ -5745,7 +5771,7 @@ def doctor_repair(
     """
 
     async def _run() -> dict[str, Any]:
-        from .storage import create_diagnostic_backup, heal_archive_locks
+        from .storage import collect_lock_status, create_diagnostic_backup, heal_archive_locks
 
         settings = get_settings()
         await ensure_schema()
@@ -5778,8 +5804,27 @@ def doctor_repair(
 
         # 2a: Heal stale locks
         if dry_run:
-            console.print("  [dim]Would heal stale locks[/dim]")
-            repair_results["safe_repairs"].append({"action": "heal_locks", "dry_run": True})
+            lock_status = collect_lock_status(settings, project_slug=project_slug)
+            stale_locks = [
+                lock
+                for lock in lock_status.get("locks", [])
+                if isinstance(lock, dict) and lock.get("stale_suspected")
+            ]
+            reason_codes = sorted(
+                {
+                    str(lock.get("reason_code"))
+                    for lock in stale_locks
+                    if lock.get("reason_code")
+                }
+            )
+            console.print(f"  [dim]Would heal {len(stale_locks)} stale lock(s)[/dim]")
+            repair_results["safe_repairs"].append({
+                "action": "heal_locks",
+                "count": len(stale_locks),
+                "reason_codes": reason_codes,
+                "scan": lock_status.get("scan", {}),
+                "dry_run": True,
+            })
         else:
             try:
                 lock_result = await heal_archive_locks(settings, project_slug=project_slug)
@@ -5788,7 +5833,12 @@ def doctor_repair(
                     console.print(f"  [green]Healed {healed} stale lock(s)[/green]")
                 else:
                     console.print("  [dim]No stale locks to heal[/dim]")
-                repair_results["safe_repairs"].append({"action": "heal_locks", "healed": healed})
+                repair_results["safe_repairs"].append({
+                    "action": "heal_locks",
+                    "healed": healed,
+                    "reason_codes": lock_result.get("reason_codes", []),
+                    "scan": lock_result.get("scan", {}),
+                })
             except Exception as e:
                 repair_results["errors"].append(f"Lock healing failed: {e}")
                 console.print(f"  [red]Lock healing failed:[/red] {e}")

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -44,7 +44,7 @@ from .db import ensure_schema, get_session
 from .storage import (
     ProjectArchive,
     archive_write_lock,
-    collect_lock_status,
+    collect_lock_status_async,
     ensure_archive,
     get_agent_communication_graph,
     get_archive_tree,
@@ -1913,7 +1913,7 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
             """Return metadata about active archive locks for observability."""
 
             settings_local = get_settings()
-            payload = collect_lock_status(settings_local)
+            payload = await collect_lock_status_async(settings_local)
             return JSONResponse(payload)
 
         async def _build_unified_inbox_payload(

--- a/src/mcp_agent_mail/storage.py
+++ b/src/mcp_agent_mail/storage.py
@@ -1281,6 +1281,122 @@ def _list_rglob_paths(root: Path, pattern: str) -> list[Path]:
     return list(root.rglob(pattern))
 
 
+_LOCK_STATUS_SCAN_TIMEOUT_SECONDS = 3.0
+_LOCK_STATUS_SCAN_MAX_ENTRIES = 20_000
+_LOCK_STATUS_SCAN_MAX_LOCKS = 2_000
+
+
+def _lock_category(lock_path: Path) -> str:
+    if lock_path.name == ".archive.lock":
+        return "archive"
+    if lock_path.name == ".commit.lock":
+        return "commit"
+    return "custom"
+
+
+def _lock_reason_code(
+    *,
+    metadata_present: bool,
+    metadata_error: bool,
+    owner_alive: bool | None,
+    age_seconds: Any,
+    stale_timeout_seconds: float,
+    stale_suspected: bool,
+) -> str:
+    if stale_suspected:
+        if owner_alive is False:
+            return "lock_owner_dead"
+        if isinstance(age_seconds, (int, float)) and age_seconds >= stale_timeout_seconds:
+            if owner_alive is True:
+                return "lock_owner_alive_age_exceeded"
+            if not metadata_present:
+                return "lock_missing_metadata_age_exceeded"
+            return "lock_age_exceeded"
+        return "lock_stale"
+    if metadata_error:
+        return "lock_metadata_unreadable"
+    if owner_alive is True:
+        return "lock_owner_alive"
+    if owner_alive is False:
+        return "lock_owner_dead_not_stale"
+    if not metadata_present:
+        return "lock_metadata_missing"
+    return "lock_owner_unknown"
+
+
+def _lock_safe_remediation(reason_code: str) -> str:
+    if reason_code == "lock_owner_alive_age_exceeded":
+        return (
+            "Owner process is still alive but the lock aged past the stale threshold; "
+            "restart the wedged owner if health probes fail, then run `am doctor repair`."
+        )
+    if reason_code in {"lock_owner_dead", "lock_missing_metadata_age_exceeded", "lock_age_exceeded", "lock_stale"}:
+        return "Run `am doctor repair` to remove stale lock artifacts after the diagnostic backup."
+    if reason_code == "lock_metadata_unreadable":
+        return "Inspect the sidecar metadata; `am doctor repair` can clear it when the lock is stale."
+    return "No automatic repair is recommended while the lock is fresh or owner state is unknown."
+
+
+def _scan_lock_paths(
+    root: Path,
+    *,
+    timeout_seconds: float = _LOCK_STATUS_SCAN_TIMEOUT_SECONDS,
+    max_entries: int = _LOCK_STATUS_SCAN_MAX_ENTRIES,
+    max_locks: int = _LOCK_STATUS_SCAN_MAX_LOCKS,
+) -> tuple[list[Path], dict[str, Any]]:
+    started = time.monotonic()
+    deadline = started + max(0.1, timeout_seconds)
+    stack = [root]
+    locks: list[Path] = []
+    entries_scanned = 0
+    dirs_scanned = 0
+    timed_out = False
+    truncated = False
+
+    while stack:
+        if time.monotonic() >= deadline:
+            timed_out = True
+            break
+        current = stack.pop()
+        dirs_scanned += 1
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    entries_scanned += 1
+                    if entries_scanned >= max_entries:
+                        truncated = True
+                        break
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        elif entry.is_file(follow_symlinks=False) and entry.name.endswith(".lock"):
+                            locks.append(Path(entry.path))
+                            if len(locks) >= max_locks:
+                                truncated = True
+                                break
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+        if truncated:
+            break
+
+    locks.sort(key=lambda p: str(p))
+    return locks, {
+        "root": str(root),
+        "duration_seconds": round(time.monotonic() - started, 4),
+        "entries_scanned": entries_scanned,
+        "dirs_scanned": dirs_scanned,
+        "locks_discovered": len(locks),
+        "timed_out": timed_out,
+        "truncated": truncated,
+        "max_entries": max_entries,
+        "max_locks": max_locks,
+        "timeout_seconds": timeout_seconds,
+        "reason_code": "lock_inventory_scan_incomplete" if timed_out or truncated else "lock_inventory_ok",
+    }
+
+
 def _restore_bundle_into_archive(bundle_to_restore: Path, target_root: Path) -> None:
     """Restore a Git bundle into the archive root without deleting the source bundle first."""
     import shutil
@@ -1317,7 +1433,14 @@ def _ensure_str(value: str | bytes) -> str:
     return value
 
 
-def collect_lock_status(settings: Settings, project_slug: str | None = None) -> dict[str, Any]:
+def collect_lock_status(
+    settings: Settings,
+    project_slug: str | None = None,
+    *,
+    timeout_seconds: float = _LOCK_STATUS_SCAN_TIMEOUT_SECONDS,
+    max_entries: int = _LOCK_STATUS_SCAN_MAX_ENTRIES,
+    max_locks: int = _LOCK_STATUS_SCAN_MAX_LOCKS,
+) -> dict[str, Any]:
     """Return structured metadata about active archive locks."""
 
     root = Path(settings.storage.root).expanduser().resolve()
@@ -1325,15 +1448,35 @@ def collect_lock_status(settings: Settings, project_slug: str | None = None) -> 
         root = root / "projects" / project_slug
     locks: list[dict[str, Any]] = []
     summary = {"total": 0, "active": 0, "stale": 0, "metadata_missing": 0}
+    scan: dict[str, Any] = {
+        "root": str(root),
+        "duration_seconds": 0.0,
+        "entries_scanned": 0,
+        "dirs_scanned": 0,
+        "locks_discovered": 0,
+        "timed_out": False,
+        "truncated": False,
+        "max_entries": max_entries,
+        "max_locks": max_locks,
+        "timeout_seconds": timeout_seconds,
+        "reason_code": "lock_inventory_missing_root",
+    }
 
     if root.exists():
         now = time.time()
-        for lock_path in sorted(root.rglob("*.lock"), key=lambda p: str(p)):
+        lock_paths, scan = _scan_lock_paths(
+            root,
+            timeout_seconds=timeout_seconds,
+            max_entries=max_entries,
+            max_locks=max_locks,
+        )
+        for lock_path in lock_paths:
             metadata_path = lock_path.parent / f"{lock_path.name}.owner.json"
             if not lock_path.exists():
                 continue
             metadata_present = metadata_path.exists()
-            if lock_path.name != ".archive.lock" and not metadata_present:
+            category = _lock_category(lock_path)
+            if category == "custom" and not metadata_present:
                 continue
 
             info: dict[str, Any] = {
@@ -1341,7 +1484,7 @@ def collect_lock_status(settings: Settings, project_slug: str | None = None) -> 
                 "metadata_path": str(metadata_path) if metadata_present else None,
                 "status": "held",
                 "metadata_present": metadata_present,
-                "category": "archive" if lock_path.name == ".archive.lock" else "custom",
+                "category": category,
             }
 
             with contextlib.suppress(Exception):
@@ -1350,12 +1493,15 @@ def collect_lock_status(settings: Settings, project_slug: str | None = None) -> 
                 info["modified_ts"] = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
 
             metadata: dict[str, Any] = {}
+            metadata_error = False
             if metadata_present:
                 try:
                     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
                 except Exception:
+                    metadata_error = True
                     metadata = {}
             info["metadata"] = metadata
+            info["metadata_error"] = metadata_error
 
             pid_val = metadata.get("pid")
             pid_int: int | None = None
@@ -1388,6 +1534,16 @@ def collect_lock_status(settings: Settings, project_slug: str | None = None) -> 
             if owner_alive is False or (stale_threshold > 0 and isinstance(age_val, (int, float)) and age_val >= stale_threshold):
                 is_stale = True
             info["stale_suspected"] = is_stale
+            reason_code = _lock_reason_code(
+                metadata_present=metadata_present,
+                metadata_error=metadata_error,
+                owner_alive=owner_alive,
+                age_seconds=age_val,
+                stale_timeout_seconds=stale_threshold,
+                stale_suspected=is_stale,
+            )
+            info["reason_code"] = reason_code
+            info["safe_remediation"] = _lock_safe_remediation(reason_code)
 
             summary["total"] += 1
 
@@ -1400,7 +1556,30 @@ def collect_lock_status(settings: Settings, project_slug: str | None = None) -> 
 
             locks.append(info)
 
-    return {"locks": locks, "summary": summary}
+    summary["scan_truncated"] = bool(scan.get("truncated"))
+    summary["scan_timed_out"] = bool(scan.get("timed_out"))
+    summary["reason_code"] = scan.get("reason_code", "lock_inventory_unknown")
+    return {"locks": locks, "summary": summary, "scan": scan}
+
+
+async def collect_lock_status_async(
+    settings: Settings,
+    project_slug: str | None = None,
+    *,
+    timeout_seconds: float = _LOCK_STATUS_SCAN_TIMEOUT_SECONDS,
+    max_entries: int = _LOCK_STATUS_SCAN_MAX_ENTRIES,
+    max_locks: int = _LOCK_STATUS_SCAN_MAX_LOCKS,
+) -> dict[str, Any]:
+    """Collect lock metadata off the event loop with an internally bounded scan."""
+
+    return await _to_thread(
+        collect_lock_status,
+        settings,
+        project_slug,
+        timeout_seconds=timeout_seconds,
+        max_entries=max_entries,
+        max_locks=max_locks,
+    )
 
 
 async def ensure_archive_root(settings: Settings) -> tuple[Path, Repo]:
@@ -2309,11 +2488,14 @@ async def heal_archive_locks(settings: Settings, project_slug: str | None = None
         "locks_scanned": 0,
         "locks_removed": [],
         "metadata_removed": [],
+        "reason_codes": [],
+        "healed": 0,
     }
     if not await _to_thread(_path_exists, root):
         return summary
 
-    lock_paths = sorted(await _to_thread(_list_rglob_paths, root, "*.lock"), key=str)
+    lock_paths, scan = await _to_thread(_scan_lock_paths, root)
+    summary["scan"] = scan
     for lock_path_item in lock_paths:
         # rglob returns Path objects at runtime; cast for type checker
         lock_path = cast(Path, lock_path_item)
@@ -2331,10 +2513,16 @@ async def heal_archive_locks(settings: Settings, project_slug: str | None = None
             # to heal"). Sharing one staleness definition keeps check and repair
             # in agreement: a lock is healed if its owner is provably gone OR its
             # age exceeds the threshold.
-            lock = AsyncFileLock(lock_path, timeout_seconds=0.0)
+            metadata_path = lock_path.parent / f"{lock_path.name}.owner.json"
+            stale_timeout = AsyncFileLock(lock_path)._stale_timeout
+            lock = AsyncFileLock(lock_path, timeout_seconds=0.0, stale_timeout_seconds=stale_timeout)
             removed = await _to_thread(lock._cleanup_if_stale)
             if removed:
                 summary["locks_removed"].append(str(lock_path))
+                if await _to_thread(_path_exists, metadata_path):
+                    summary["reason_codes"].append("lock_stale_removed_with_metadata")
+                else:
+                    summary["reason_codes"].append("lock_stale_removed")
         except FileNotFoundError:
             continue
 
@@ -2356,6 +2544,7 @@ async def heal_archive_locks(settings: Settings, project_slug: str | None = None
         except PermissionError:
             continue
 
+    summary["healed"] = len(summary["locks_removed"]) + len(summary["metadata_removed"])
     return summary
 
 

--- a/tests/test_git_archive_failures.py
+++ b/tests/test_git_archive_failures.py
@@ -24,6 +24,7 @@ from mcp_agent_mail.storage import (
     AsyncFileLock,
     archive_write_lock,
     collect_lock_status,
+    collect_lock_status_async,
     ensure_archive,
     ensure_archive_root,
     heal_archive_locks,
@@ -370,6 +371,65 @@ class TestLockHealing:
         assert entry["stale_suspected"] is True
         assert payload["summary"]["metadata_missing"] == 1
         assert payload["summary"]["stale"] == 1
+        assert entry["reason_code"] == "lock_missing_metadata_age_exceeded"
+        assert payload["scan"]["reason_code"] == "lock_inventory_ok"
+
+    @pytest.mark.asyncio
+    async def test_heal_archive_locks_cleans_aged_live_owner_lock(self, isolated_env):
+        """A wedged live owner with an aged lock is repairable and machine-classified."""
+        settings = get_settings()
+        storage_root = Path(settings.storage.root).expanduser().resolve()
+        project_dir = storage_root / "projects" / "wedged-live-owner"
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        lock_path = project_dir / ".archive.lock"
+        metadata_path = project_dir / ".archive.lock.owner.json"
+        lock_path.touch()
+        stale_time = time.time() - 400
+        os.utime(lock_path, (stale_time, stale_time))
+        metadata_path.write_text(
+            f'{{"pid": {os.getpid()}, "created_ts": {stale_time}}}',
+            encoding="utf-8",
+        )
+
+        payload = collect_lock_status(settings, project_slug="wedged-live-owner")
+        entry = next(item for item in payload["locks"] if item["path"] == str(lock_path))
+
+        assert entry["owner_alive"] is True
+        assert entry["stale_suspected"] is True
+        assert entry["reason_code"] == "lock_owner_alive_age_exceeded"
+        assert "restart the wedged owner" in entry["safe_remediation"]
+
+        result = await heal_archive_locks(settings, project_slug="wedged-live-owner")
+
+        assert str(lock_path) in result.get("locks_removed", [])
+        assert result.get("healed") == 1
+        assert not lock_path.exists()
+        assert not metadata_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_collect_lock_status_async_reports_commit_lock_reason(self, isolated_env):
+        """Async callers get bounded lock inventory without blocking the event loop."""
+        settings = get_settings()
+        storage_root = Path(settings.storage.root).expanduser().resolve()
+        project_dir = storage_root / "projects" / "commit-lock"
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        lock_path = project_dir / ".commit.lock"
+        metadata_path = project_dir / ".commit.lock.owner.json"
+        lock_path.touch()
+        metadata_path.write_text(
+            f'{{"pid": {os.getpid()}, "created_ts": {time.time()}}}',
+            encoding="utf-8",
+        )
+
+        payload = await collect_lock_status_async(settings, project_slug="commit-lock")
+        entry = next(item for item in payload["locks"] if item["path"] == str(lock_path))
+
+        assert entry["category"] == "commit"
+        assert entry["reason_code"] == "lock_owner_alive"
+        assert payload["summary"]["scan_timed_out"] is False
+        assert payload["scan"]["locks_discovered"] >= 1
 
     @pytest.mark.asyncio
     async def test_heal_archive_locks_handles_missing_root(self, isolated_env, monkeypatch):


### PR DESCRIPTION
## Summary
- bounds lock inventory scanning with max entries/locks/time metadata
- moves HTTP/resource lock inventory callers off the event loop
- adds machine-readable reason codes and safe remediation text for stale locks
- makes doctor dry-run/repair report scan metadata and reason codes

## Live evidence
- local upstream reset to da2baa7 recovered basic liveness only after killing stale orphan PID 41715
- unbounded archive lock scan over ~/.mcp_agent_mail_git_mailbox_repo took ~7.5s for 3 lock files
- patched collect_lock_status on the same archive root returned in 0.156s, truncating at 20,000 entries with reason_code=lock_inventory_scan_incomplete
- macro_start_session still missed the <5s operational bar on upstream da2baa7 before this patch path

## Validation
- uv run python -m py_compile src/mcp_agent_mail/storage.py src/mcp_agent_mail/app.py src/mcp_agent_mail/http.py src/mcp_agent_mail/cli.py tests/test_git_archive_failures.py
- uv run ruff check src/mcp_agent_mail/storage.py src/mcp_agent_mail/app.py src/mcp_agent_mail/http.py src/mcp_agent_mail/cli.py tests/test_git_archive_failures.py
- uv run pytest tests/test_git_archive_failures.py -q (28 passed)
- uv run pytest tests/test_storage_edges.py -q (33 passed)
- git diff --check