### PR TITLE
fix: reservation sweeper starves the event loop on broad glob reservations

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -1319,18 +1319,46 @@ def _latest_filesystem_activity(paths: Sequence[Path]) -> Optional[datetime]:
     return max(mtimes)
 
 
-def _latest_git_activity(repo: Optional[Repo], matches: Sequence[Path]) -> Optional[datetime]:
+def _latest_git_activity(
+    repo: Optional[Repo],
+    matches: Sequence[Path],
+    pattern: Optional[str] = None,
+) -> Optional[datetime]:
     if repo is None:
         return None
     repo_root = Path(repo.working_tree_dir or "").resolve()
-    commit_times: list[datetime] = []
-    for match in matches:
+
+    # The result is the max commit time over per-path latest commits, which
+    # equals the latest commit touching ANY matched path — so a single rev
+    # walk with one pathspec is equivalent to walking per file. A per-file
+    # iter_commits here once ran 56k sequential git walks on the event loop
+    # for a `frontend/**` reservation, starving the HTTP server.
+    if pattern and not _is_virtual_namespace(pattern):
+        normalized = _normalize_pattern(pattern)
+        if normalized:
+            pathspec = f":(glob){normalized}" if _contains_glob(normalized) else normalized
+            try:
+                commit = next(repo.iter_commits(paths=[pathspec], max_count=1))
+                return datetime.fromtimestamp(commit.committed_date, tz=timezone.utc)
+            except StopIteration:
+                return None
+            except Exception:
+                pass  # fall through to per-path walk on odd pathspecs
+
+    # Fallback: chunked pathspec walks over the resolved matches (capped so a
+    # pathological match set cannot stall the loop).
+    rel_paths: list[str] = []
+    for match in matches[:2000]:
         try:
-            rel_path = match.resolve().relative_to(repo_root)
+            rel_paths.append(str(match.resolve().relative_to(repo_root)))
         except Exception:
             continue
+    commit_times: list[datetime] = []
+    chunk_size = 500
+    for i in range(0, len(rel_paths), chunk_size):
+        chunk = rel_paths[i : i + chunk_size]
         try:
-            commit = next(repo.iter_commits(paths=str(rel_path), max_count=1))
+            commit = next(repo.iter_commits(paths=chunk, max_count=1))
         except StopIteration:
             continue
         except Exception:
@@ -3980,7 +4008,7 @@ async def _collect_file_reservation_statuses(
                 matches = _collect_matching_paths(workspace, reservation.path_pattern)
                 if matches:
                     fs_activity = _latest_filesystem_activity(matches)
-                    git_activity = _latest_git_activity(repo, matches)
+                    git_activity = _latest_git_activity(repo, matches, pattern=reservation.path_pattern)
 
             agent_inactive = (
                 agent_last_active is None or (moment - agent_last_active).total_seconds() > inactivity_seconds

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -1306,17 +1306,26 @@ def _collect_matching_paths(base: Path, pattern: str) -> list[Path]:
     return [candidate]
 
 
-def _latest_filesystem_activity(paths: Sequence[Path]) -> Optional[datetime]:
-    mtimes: list[datetime] = []
+def _latest_filesystem_activity(
+    paths: Sequence[Path],
+    recent_threshold: Optional[datetime] = None,
+) -> Optional[datetime]:
+    # When the caller only needs "any activity since recent_threshold" (the
+    # staleness sweeper), stop at the first qualifying mtime instead of
+    # stat()ing every match — broad globs like frontend/** can match tens of
+    # thousands of files per tick.
+    latest: Optional[datetime] = None
     for path in paths:
         try:
             stat = path.stat()
         except OSError:
             continue
-        mtimes.append(datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc))
-    if not mtimes:
-        return None
-    return max(mtimes)
+        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+        if latest is None or mtime > latest:
+            latest = mtime
+        if recent_threshold is not None and mtime >= recent_threshold:
+            return latest
+    return latest
 
 
 def _latest_git_activity(
@@ -4007,7 +4016,10 @@ async def _collect_file_reservation_statuses(
             if workspace is not None:
                 matches = _collect_matching_paths(workspace, reservation.path_pattern)
                 if matches:
-                    fs_activity = _latest_filesystem_activity(matches)
+                    fs_activity = _latest_filesystem_activity(
+                        matches,
+                        recent_threshold=moment - timedelta(seconds=activity_grace),
+                    )
                     git_activity = _latest_git_activity(repo, matches, pattern=reservation.path_pattern)
 
             agent_inactive = (


### PR DESCRIPTION
## Problem

The file-reservation staleness sweeper (`_collect_file_reservation_statuses`) runs synchronously on the event loop and, for every reservation, executes **one `iter_commits(paths=<file>)` per glob-matched file**.

A reservation like `frontend/**` on a workspace with node_modules matched **56,103 files** on my machine → ~80 seconds of sequential git forks per 60-second cleanup tick → the HTTP accept loop never ran. Result: full server outage with the port still listening (TCP handshake completes via kernel backlog, no response ever; MCP and Web UI both hang indefinitely). Diagnosed via `sample` stack dumps showing the loop pinned in `subprocess_fork_exec` / `_buffered_readline` from GitPython.

## Fix

**Commit 1 — git walk**: `_latest_git_activity` only returns the max commit time across matches, which equals the latest commit touching *any* match. So a single rev walk with one `:(glob)<pattern>` pathspec is semantically equivalent to per-file walks. Measured on the repro workspace: **8ms vs ~80s per tick**. Falls back to capped, chunked pathspec walks when no pattern is available.

**Commit 2 — stat pass**: `_latest_filesystem_activity` now accepts a `recent_threshold` and stops at the first mtime inside the activity grace window — the reservation is provably non-stale at that point. The reported `last_fs_activity` stays exact for idle reservations (full scan still runs when nothing is recent).

## Testing

- `tests/test_resource_cleanup.py` (13 passed) and `tests/test_mcp_resources.py` (29 passed)
- Live verification: server that was hard-down recovered to 40ms responses, cleanup ticks from ~80s to ~0.1s, idle CPU from ~20% to 0.3%

## Notes

A related aggravator worth a maintainer's eye: the mailbox git repo accumulates loose objects unboundedly (GitPython commits never trigger git auto-gc) — mine reached 100k loose objects / 465MB, making every walk slower. Periodic `git gc` (or `gc.auto`-equivalent in the server) might be worth scheduling server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)