### PR TITLE
fix(guard): invoke husky h with argv0=pre-commit, not .orig

### DIFF
--- a/src/mcp_agent_mail/guard.py
+++ b/src/mcp_agent_mail/guard.py
@@ -27,7 +27,11 @@ def _render_chain_runner_script(hook_name: str) -> str:
     Behavior:
     - Runs executables in hooks.d/<hook_name>/* in lexical order.
     - For pre-push, reads STDIN once and forwards it to each child hook.
-    - If a <hook_name>.orig exists and is executable, it is invoked last.
+    - If husky's resolver (`h`) sits next to this runner, invoke it last
+      with argv0=<hook_name> so basename($0) still finds the tracked hook.
+      Do not exec a renamed <hook_name>.orig through husky — that makes
+      basename($0) look up a non-existent tracked file and exit 0.
+    - Else if a <hook_name>.orig exists and is executable, it is invoked last.
     - Exits non-zero on the first non-zero child exit code.
     """
     lines: list[str] = [
@@ -42,6 +46,8 @@ def _render_chain_runner_script(hook_name: str) -> str:
         "HOOK_DIR = Path(__file__).parent",
         f"RUN_DIR = HOOK_DIR / 'hooks.d' / '{hook_name}'",
         f"ORIG = HOOK_DIR / '{hook_name}.orig'",
+        "HUSKY_H = HOOK_DIR / 'h'",
+        f"HOOK_ARGV0 = str(HOOK_DIR / '{hook_name}')",
         "",
         "def _is_exec(p: Path) -> bool:",
         "    try:",
@@ -71,6 +77,15 @@ def _render_chain_runner_script(hook_name: str) -> str:
         "        return subprocess.run(['python', str(path), *ARGV], input=stdin_bytes, check=False).returncode",
         "    return subprocess.run([str(path), *ARGV], input=stdin_bytes, check=False).returncode",
         "",
+        "def _run_husky_h(*, stdin_bytes=None):",
+        "    # Source husky h with $0 = <hooksDir>/<hook_name> so basename($0) is",
+        "    # the hook name (not '*.orig') and dirname(dirname($0)) is the husky root.",
+        "    return subprocess.run(",
+        "        ['/bin/sh', '-c', 'h=\"$1\"; shift; . \"$h\"', HOOK_ARGV0, str(HUSKY_H), *ARGV],",
+        "        input=stdin_bytes,",
+        "        check=False,",
+        "    ).returncode",
+        "",
     ]
     if hook_name == "pre-push":
         lines += [
@@ -81,8 +96,12 @@ def _render_chain_runner_script(hook_name: str) -> str:
             "    if rc != 0:",
             "        sys.exit(rc)",
             "",
-            "# Run the preserved original hook last (POSIX: only if it is executable).",
-            "if ORIG.exists() and (os.name != 'posix' or _is_exec(ORIG)):",
+            "# Prefer husky h (argv0=hook name) over exec'ing a renamed .orig.",
+            "if HUSKY_H.exists():",
+            "    rc = _run_husky_h(stdin_bytes=stdin_bytes)",
+            "    if rc != 0:",
+            "        sys.exit(rc)",
+            "elif ORIG.exists() and (os.name != 'posix' or _is_exec(ORIG)):",
             "    rc = _run_child(ORIG, stdin_bytes=stdin_bytes)",
             "    if rc != 0:",
             "        sys.exit(rc)",
@@ -95,8 +114,12 @@ def _render_chain_runner_script(hook_name: str) -> str:
             "    if rc != 0:",
             "        sys.exit(rc)",
             "",
-            "# Run the preserved original hook last (POSIX: only if it is executable).",
-            "if ORIG.exists() and (os.name != 'posix' or _is_exec(ORIG)):",
+            "# Prefer husky h (argv0=hook name) over exec'ing a renamed .orig.",
+            "if HUSKY_H.exists():",
+            "    rc = _run_husky_h()",
+            "    if rc != 0:",
+            "        sys.exit(rc)",
+            "elif ORIG.exists() and (os.name != 'posix' or _is_exec(ORIG)):",
             "    rc = _run_child(ORIG)",
             "    if rc != 0:",
             "        sys.exit(rc)",

--- a/tests/test_guard_worktrees.py
+++ b/tests/test_guard_worktrees.py
@@ -198,6 +198,59 @@ async def test_guard_install_relative_hookspath(isolated_env, tmp_path: Path):
 
 
 # =============================================================================
+# Husky hooksPath + basename($0) (tracked-hook must still run)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_install_guard_husky_hookspath_runs_tracked_hook(isolated_env, tmp_path: Path):
+    """install_guard on a husky repo must still run the tracked .husky/pre-commit.
+
+    husky's .husky/_/h resolves the tracked hook via basename($0). Exec'ing a
+    renamed pre-commit.orig through h looks up .husky/pre-commit.orig and
+    silently exits 0 — the tracked hook never runs.
+    """
+    settings = get_settings()
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _init_git_repo(repo)
+
+    husky = repo / ".husky"
+    husky_us = husky / "_"
+    husky_us.mkdir(parents=True)
+
+    # Minimal husky resolver (matches .husky/_/h: basename $0 → parent dir)
+    h = husky_us / "h"
+    h.write_text(
+        "#!/usr/bin/env sh\n"
+        'n=$(basename "$0")\n'
+        's=$(dirname "$(dirname "$0")")/$n\n'
+        '[ ! -f "$s" ] && exit 0\n'
+        'sh -e "$s" "$@"\n',
+        encoding="utf-8",
+    )
+    h.chmod(0o755)
+
+    stub = husky_us / "pre-commit"
+    stub.write_text('#!/usr/bin/env sh\n. "$(dirname "$0")/h"\n', encoding="utf-8")
+    stub.chmod(0o755)
+
+    tracked = husky / "pre-commit"
+    tracked.write_text("#!/usr/bin/env sh\necho HUSKY_TRACKED_HOOK_RAN\n", encoding="utf-8")
+    tracked.chmod(0o755)
+
+    _git_config(repo, "core.hooksPath", ".husky/_")
+
+    hook_path = await install_guard(settings, "husky-orig-test", repo)
+
+    result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
+    assert "HUSKY_TRACKED_HOOK_RAN" in result.stdout, (
+        f"tracked husky hook did not run; exit={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+# =============================================================================
 # Hook Preservation Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary
`install_guard` renamed an existing husky stub to `pre-commit.orig` and exec'd it last. Husky's `.husky/_/h` resolves the tracked hook via `basename($0)`, so `$0=pre-commit.orig` looks up `.husky/pre-commit.orig`, misses, and exits 0. Tracked hooks (gitleaks, lint-staged, repo guards) never ran.

## Fix
When husky's `h` sits next to the chain-runner, source `h` with `$0=<hooksDir>/pre-commit` instead of exec'ing the renamed `.orig`. Non-husky `.orig` hooks still run as before.

## Test
`test_install_guard_husky_hookspath_runs_tracked_hook` — RED on the old rename+exec, GREEN after.

Bead: bd-1nw53