### PR TITLE
feat(messaging): make cross-project approval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2101,6 +2101,7 @@ Common variables you may set:
 | `ACK_ESCALATION_CLAIM_EXCLUSIVE` | `false` | Make escalation file reservation exclusive |
 | `ACK_ESCALATION_CLAIM_HOLDER_NAME` |  | Ops agent name to own escalation file reservations |
 | `CONTACT_ENFORCEMENT_ENABLED` | `true` | Enforce contact policy before messaging |
+| `CROSS_PROJECT_CONTACT_ENFORCEMENT_ENABLED` | `true` | Require approved contact links for cross-project messaging |
 | `CONTACT_AUTO_TTL_SECONDS` | `86400` | TTL for in-session auto-approved contact links and the "recent contact" recency window (1 day) |
 | `CONTACT_PENDING_TTL_SECONDS` | `604800` | TTL for the *pending* contact-request fallback created by `send_message(auto_contact_if_blocked=True)` when in-session auto-approval is not possible — i.e. how long an async human approver has to respond (7 days) |
 | `CONTACT_AUTO_RETRY_ENABLED` | `true` | Auto-retry contact requests on policy violations |

--- a/SKILL.md
+++ b/SKILL.md
@@ -398,6 +398,7 @@ uv run python -m mcp_agent_mail.cli config set-port 9000
 | `HTTP_BEARER_TOKEN` | — | Static bearer token for auth |
 | `LLM_ENABLED` | `true` | Enable LLM for summaries/discovery |
 | `CONTACT_ENFORCEMENT_ENABLED` | `true` | Enforce contact policy |
+| `CROSS_PROJECT_CONTACT_ENFORCEMENT_ENABLED` | `true` | Require approved contact links across projects |
 
 ## Docker
 

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -7995,7 +7995,9 @@ def build_mcp_server() -> FastMCP:
                         and target_project_override is not None
                         and not settings_local.cross_project_contact_enforcement_enabled
                     ):
-                        target_agent = await _find_agent_optional(target_project_override, canonical)
+                        target_agent = await _find_agent_optional(target_project_override, display_value)
+                        if target_agent is None and canonical != display_value:
+                            target_agent = await _find_agent_optional(target_project_override, canonical)
                         if target_agent is not None:
                             pol = (getattr(target_agent, "contact_policy", "auto") or "auto").lower()
                             if pol == "block_all":
@@ -8684,7 +8686,9 @@ def build_mcp_server() -> FastMCP:
                         and target_project_override is not None
                         and not settings_local.cross_project_contact_enforcement_enabled
                     ):
-                        target_agent = await _find_agent_optional(target_project_override, canonical)
+                        target_agent = await _find_agent_optional(target_project_override, display_value)
+                        if target_agent is None and canonical != display_value:
+                            target_agent = await _find_agent_optional(target_project_override, canonical)
                         if target_agent is not None:
                             recipient_policy = (getattr(target_agent, "contact_policy", "auto") or "auto").lower()
                             if recipient_policy == "block_all":

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -7990,6 +7990,23 @@ def build_mcp_server() -> FastMCP:
                             continue
 
                     lookup_value = canonical.lower()
+                    if (
+                        explicit_override
+                        and target_project_override is not None
+                        and not settings_local.cross_project_contact_enforcement_enabled
+                    ):
+                        target_agent = await _find_agent_optional(target_project_override, canonical)
+                        if target_agent is not None:
+                            pol = (getattr(target_agent, "contact_policy", "auto") or "auto").lower()
+                            if pol == "block_all":
+                                await ctx.error("CONTACT_BLOCKED: Recipient is not accepting messages.")
+                                raise _ContactBlocked()
+                            bucket = external.setdefault(
+                                target_project_override.id or 0,
+                                {"project": target_project_override, "to": [], "cc": [], "bcc": []},
+                            )
+                            bucket[kind].append(target_agent.name)
+                            continue
                     rows = None
                     if explicit_override and target_project_override is not None:
                         rows = await sx.execute(
@@ -8662,6 +8679,23 @@ def build_mcp_server() -> FastMCP:
                             continue
 
                     lookup_value = canonical.lower()
+                    if (
+                        explicit_override
+                        and target_project_override is not None
+                        and not settings_local.cross_project_contact_enforcement_enabled
+                    ):
+                        target_agent = await _find_agent_optional(target_project_override, canonical)
+                        if target_agent is not None:
+                            recipient_policy = (getattr(target_agent, "contact_policy", "auto") or "auto").lower()
+                            if recipient_policy == "block_all":
+                                await ctx.error("CONTACT_BLOCKED: Recipient is not accepting messages.")
+                                raise _ContactBlocked()
+                            bucket = external.setdefault(
+                                target_project_override.id or 0,
+                                {"project": target_project_override, "to": [], "cc": [], "bcc": []},
+                            )
+                            bucket[kind].append(target_agent.name)
+                            continue
                     rows = None
                     if explicit_override and target_project_override is not None:
                         rows = await sx.execute(

--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -215,6 +215,9 @@ class Settings:
     ack_escalation_claim_holder_name: str
     # Contacts/links
     contact_enforcement_enabled: bool
+    # Cross-project routing normally requires an approved AgentLink. Deployments
+    # with a single trusted owner can opt out while retaining the secure default.
+    cross_project_contact_enforcement_enabled: bool
     # TTL for in-session auto-approved contact links and the
     # "recent contact" recency window used by messaging policy.
     # Short by design (default 24h) — auto-approval is a session-scoped
@@ -567,6 +570,9 @@ def _build_settings() -> Settings:
         log_level=decouple_config("LOG_LEVEL", default="INFO"),
         log_include_trace=_b("LOG_INCLUDE_TRACE", default=False),
         contact_enforcement_enabled=_b("CONTACT_ENFORCEMENT_ENABLED", default=True),
+        cross_project_contact_enforcement_enabled=_b(
+            "CROSS_PROJECT_CONTACT_ENFORCEMENT_ENABLED", default=True
+        ),
         contact_auto_ttl_seconds=_i("CONTACT_AUTO_TTL_SECONDS", default=86400),
         contact_pending_ttl_seconds=_i("CONTACT_PENDING_TTL_SECONDS", default=604800),
         contact_auto_retry_enabled=_b("CONTACT_AUTO_RETRY_ENABLED", default=True),

--- a/tests/test_contact_and_routing.py
+++ b/tests/test_contact_and_routing.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 
 import pytest
 from fastmcp import Client
 
+from mcp_agent_mail import config as _config
 from mcp_agent_mail.app import build_mcp_server
 from mcp_agent_mail.config import get_settings
 from mcp_agent_mail.db import ensure_schema, get_db_health_status, get_session
@@ -147,6 +149,70 @@ async def test_external_cross_project_routing(isolated_env):
         storage_root = Path(get_settings().storage.root).expanduser().resolve()
         ops_dir = storage_root / "projects" / "ops" / "messages"
         assert any(ops_dir.rglob("*.md"))
+
+
+@pytest.mark.asyncio
+async def test_cross_project_routing_without_approved_link_when_disabled(isolated_env, monkeypatch):
+    monkeypatch.setenv("CROSS_PROJECT_CONTACT_ENFORCEMENT_ENABLED", "false")
+    with contextlib.suppress(Exception):
+        _config.clear_settings_cache()
+
+    await ensure_schema()
+    async with get_session() as s:
+        backend = Project(slug="backend", human_key="Backend")
+        frontend = Project(slug="frontend", human_key="Frontend")
+        s.add_all([backend, frontend])
+        await s.commit()
+        await s.refresh(backend)
+        await s.refresh(frontend)
+        assert backend.id is not None and frontend.id is not None
+        sender = Agent(
+            project_id=backend.id,
+            name="Sender",
+            program="codex",
+            model="gpt-5",
+            task_description="",
+            registration_token="sender-token",
+        )
+        recipient = Agent(
+            project_id=frontend.id,
+            name="Recipient",
+            program="codex",
+            model="gpt-5",
+            task_description="",
+            registration_token="recipient-token",
+        )
+        s.add_all([sender, recipient])
+        await s.commit()
+
+    server = build_mcp_server()
+    async with Client(server) as client:
+        sent = await client.call_tool(
+            "send_message",
+            {
+                "project_key": "Backend",
+                "sender_name": "Sender",
+                "sender_token": "sender-token",
+                "to": ["project:Frontend#Recipient"],
+                "subject": "Cross",
+                "body_md": "hello",
+            },
+        )
+        deliveries = sent.data.get("deliveries") or []
+        assert any(delivery.get("project") == "Frontend" for delivery in deliveries)
+        message_id = deliveries[0]["payload"]["id"]
+
+        reply = await client.call_tool(
+            "reply_message",
+            {
+                "project_key": "Frontend",
+                "message_id": message_id,
+                "sender_name": "Recipient",
+                "sender_token": "recipient-token",
+                "body_md": "ack",
+            },
+        )
+        assert any(delivery.get("project") == "Backend" for delivery in reply.data.get("deliveries") or [])
 
 
 @pytest.mark.asyncio

--- a/tests/test_contact_and_routing.py
+++ b/tests/test_contact_and_routing.py
@@ -168,7 +168,7 @@ async def test_cross_project_routing_without_approved_link_when_disabled(isolate
         assert backend.id is not None and frontend.id is not None
         sender = Agent(
             project_id=backend.id,
-            name="Sender",
+            name="cross-trust-sender",
             program="codex",
             model="gpt-5",
             task_description="",
@@ -176,7 +176,7 @@ async def test_cross_project_routing_without_approved_link_when_disabled(isolate
         )
         recipient = Agent(
             project_id=frontend.id,
-            name="Recipient",
+            name="cross-trust-receiver",
             program="codex",
             model="gpt-5",
             task_description="",
@@ -191,9 +191,9 @@ async def test_cross_project_routing_without_approved_link_when_disabled(isolate
             "send_message",
             {
                 "project_key": "Backend",
-                "sender_name": "Sender",
+                "sender_name": "cross-trust-sender",
                 "sender_token": "sender-token",
-                "to": ["project:Frontend#Recipient"],
+                "to": ["project:Frontend#cross-trust-receiver"],
                 "subject": "Cross",
                 "body_md": "hello",
             },
@@ -207,7 +207,7 @@ async def test_cross_project_routing_without_approved_link_when_disabled(isolate
             {
                 "project_key": "Frontend",
                 "message_id": message_id,
-                "sender_name": "Recipient",
+                "sender_name": "cross-trust-receiver",
                 "sender_token": "recipient-token",
                 "body_md": "ack",
             },


### PR DESCRIPTION
## Summary

Adds CROSS_PROJECT_CONTACT_ENFORCEMENT_ENABLED, defaulting to true. When disabled, explicitly addressed cross-project recipients can receive sends and replies without an approved AgentLink.

The existing secure behavior remains the default. Recipient policy block_all is still enforced. Bare recipient names remain unchanged, so cross-project routing stays explicit and unambiguous.

Fixes #257.

## Verification

- uv run ruff check src/mcp_agent_mail/config.py src/mcp_agent_mail/app.py tests/test_contact_and_routing.py
- uv run pytest tests/test_contact_policy.py tests/test_contact_and_routing.py -q