### PR TITLE
Only divert a .orig to husky's resolver when it is nothing but a stub

### DIFF
--- a/src/mcp_agent_mail/guard.py
+++ b/src/mcp_agent_mail/guard.py
@@ -20,6 +20,14 @@ __all__ = [
 ]
 
 
+# A husky v9 stub's single effective statement sources its sibling resolver
+# ``h``. Tolerate the spellings husky (and hand-rolled equivalents) emit:
+# ``.`` vs ``source``, double/single/absent quoting, and ``$(dirname "$0")``
+# vs ``${0%/*}``, plus surrounding whitespace and a trailing ``;``.
+_HUSKY_DIR_EXPR = r'''(?:\$\([ \t]*dirname[ \t]+(?:--[ \t]+)?["']?\$\{?0\}?["']?[ \t]*\)|\$\{0%/\*\})'''
+_HUSKY_SOURCE_PATTERN = r'''^(?:\.|source)[ \t]+(["']?)''' + _HUSKY_DIR_EXPR + r'''/h\1[ \t]*;?[ \t]*$'''
+
+
 def _render_chain_runner_script(hook_name: str) -> str:
     """
     Render a Python chain-runner for the given Git hook name.
@@ -33,7 +41,11 @@ def _render_chain_runner_script(hook_name: str) -> str:
       the runner sources ``h`` through /bin/sh with argv0 set to the real
       hook name. Exec'ing the renamed ``<hook_name>.orig`` directly would
       make husky look up a non-existent ``.husky/<hook_name>.orig`` and
-      silently skip the user's tracked hook.
+      silently skip the user's tracked hook. That diversion applies only to a
+      file that is *nothing but* a husky stub (optional shebang, blank lines,
+      ``#`` comments, and exactly one statement sourcing ``h``); a
+      hand-written hook that merely also sources ``h`` is exec'd directly so
+      that its own body still runs.
     - On Windows, where CreateProcess cannot honor shebangs, children are
       dispatched by suffix (``.py`` via ``python``; ``.exe/.com/.bat/.cmd``
       directly) and everything else — notably a preserved shell-script
@@ -45,6 +57,7 @@ def _render_chain_runner_script(hook_name: str) -> str:
         "#!/usr/bin/env python3",
         f"# mcp-agent-mail chain-runner ({hook_name})",
         "import os",
+        "import re",
         "import sys",
         "import stat",
         "import subprocess",
@@ -127,17 +140,38 @@ def _render_chain_runner_script(hook_name: str) -> str:
         "                argv = [_win_sh(), str(path), *ARGV]",
         "    return subprocess.run(argv, input=stdin_bytes, check=False).returncode",
         "",
+        f"HUSKY_SOURCE_RE = re.compile({_HUSKY_SOURCE_PATTERN!r})",
+        "",
         "def _is_husky_stub(path: Path) -> bool:",
         "    # husky v9 keeps its hooks in <repo>/.husky/_ next to a resolver",
         "    # named 'h'; each stub just sources h, and h derives the tracked",
         "    # hook name from basename($0).",
+        "    #",
+        "    # Only a file that is *nothing but* such a stub may be diverted to",
+        "    # the resolver: an optional shebang, blank lines, '#' comments, and",
+        "    # exactly one effective statement sourcing 'h'. A hand-written hook",
+        "    # that does its own work AND also sources 'h' is a CUSTOM hook and",
+        "    # must be exec'd directly, or its whole body is silently discarded.",
+        "    # Bias to CUSTOM whenever unsure: re-running a custom hook that also",
+        "    # sources 'h' is recoverable; dropping the user's hook is not.",
         "    if os.name != 'posix' or not HUSKY_H.is_file():",
         "        return False",
         "    try:",
         "        text = path.read_text(encoding='utf-8', errors='ignore')",
         "    except Exception:",
         "        return False",
-        "    return '/h\"' in text",
+        "    body = text.splitlines()",
+        "    if body and body[0].startswith('#!'):",
+        "        body = body[1:]",
+        "    sourced = 0",
+        "    for raw in body:",
+        "        line = raw.strip()",
+        "        if not line or line.startswith('#'):",
+        "            continue",
+        "        if sourced or not HUSKY_SOURCE_RE.match(line):",
+        "            return False",
+        "        sourced = 1",
+        "    return sourced == 1",
         "",
         "def _run_orig(*, stdin_bytes=None):",
         "    if _is_husky_stub(ORIG):",

--- a/tests/test_guard_worktrees.py
+++ b/tests/test_guard_worktrees.py
@@ -202,11 +202,20 @@ async def test_guard_install_relative_hookspath(isolated_env, tmp_path: Path):
 # =============================================================================
 
 
-def _write_husky_v9_layout(repo: Path, tracked_body: str) -> tuple[Path, Path]:
+def _write_husky_v9_layout(
+    repo: Path,
+    tracked_body: str,
+    *,
+    stub_body: str | None = None,
+) -> tuple[Path, Path]:
     """Create a minimal husky v9 layout: .husky/_/{h,pre-commit} + tracked hook.
 
     Mirrors husky v9's real resolver: ``h`` derives the tracked hook name from
     basename($0) and runs ``.husky/<name>`` if present, else exits 0.
+
+    ``stub_body`` overrides the contents of ``.husky/_/pre-commit`` -- the file
+    install_guard preserves as ``pre-commit.orig`` -- so tests can install a
+    hand-written hook in the slot where a pure husky stub normally sits.
     """
     husky_dir = repo / ".husky"
     runtime_dir = husky_dir / "_"
@@ -225,7 +234,10 @@ def _write_husky_v9_layout(repo: Path, tracked_body: str) -> tuple[Path, Path]:
     resolver.chmod(0o755)
 
     stub = runtime_dir / "pre-commit"
-    stub.write_text('#!/usr/bin/env sh\n. "$(dirname "$0")/h"\n', encoding="utf-8")
+    stub.write_text(
+        stub_body if stub_body is not None else '#!/usr/bin/env sh\n. "$(dirname "$0")/h"\n',
+        encoding="utf-8",
+    )
     stub.chmod(0o755)
 
     tracked = husky_dir / "pre-commit"
@@ -285,6 +297,155 @@ async def test_guard_install_husky_v9_propagates_tracked_hook_failure(isolated_e
     result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
     assert "HUSKY_TRACKED_RAN" in result.stdout
     assert result.returncode != 0
+
+
+@pytest.mark.asyncio
+async def test_guard_husky_stub_detection_accepts_shell_param_expansion(isolated_env, tmp_path: Path):
+    """A pure stub written the way husky v9 actually emits it is still diverted.
+
+    Real ``.husky/_/<hook>`` stubs source the resolver as ``. "${0%/*}/h"``,
+    not via ``dirname``. The stub detector must accept both spellings, or the
+    diversion (argv0 = real hook name) never happens and the tracked hook is
+    silently skipped again.
+    """
+    settings = get_settings()
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _init_git_repo(repo)
+
+    _write_husky_v9_layout(
+        repo,
+        "#!/usr/bin/env sh\necho HUSKY_TRACKED_RAN\n",
+        stub_body='#!/usr/bin/env sh\n\n# husky stub\n. "${0%/*}/h"\n',
+    )
+    _git_config(repo, "core.hooksPath", ".husky/_")
+
+    hook_path = await install_guard(settings, "husky-v9-param-expansion", repo)
+
+    result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
+    assert result.returncode == 0, (
+        f"chain-runner failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "HUSKY_TRACKED_RAN" in result.stdout, (
+        f"tracked husky hook did not run: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_guard_hybrid_custom_hook_that_also_sources_husky_h_still_runs(
+    isolated_env, tmp_path: Path
+):
+    """A hand-written hook that ALSO sources husky's ``h`` must run its own body.
+
+    A bare ``'/h"' in text`` check misclassifies such a hook as a pure husky
+    stub, so the chain-runner sources ``h`` instead of exec'ing the preserved
+    ``.orig`` -- and the user's entire custom body is silently discarded. The
+    detector must only divert files that are *nothing but* a husky stub.
+    """
+    settings = get_settings()
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _init_git_repo(repo)
+
+    # NOTE: statements AFTER the source line are deliberately not asserted --
+    # husky's resolver ends in `exit`, which terminates the sourcing script.
+    # The regression is about the body BEFORE it being dropped entirely.
+    _write_husky_v9_layout(
+        repo,
+        "#!/usr/bin/env sh\necho HUSKY_TRACKED_RAN\n",
+        stub_body=(
+            "#!/usr/bin/env sh\n"
+            "echo CUSTOM_ORIG_RAN\n"
+            'touch "$(git rev-parse --show-toplevel)/CUSTOM_RAN"\n'
+            '. "$(dirname "$0")/h"\n'
+            "echo CUSTOM_TAIL_RAN\n"
+        ),
+    )
+    _git_config(repo, "core.hooksPath", ".husky/_")
+
+    hook_path = await install_guard(settings, "husky-v9-hybrid", repo)
+
+    result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
+    assert result.returncode == 0, (
+        f"chain-runner failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "CUSTOM_ORIG_RAN" in result.stdout, (
+        f"custom hook body was silently skipped: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    assert (repo / "CUSTOM_RAN").exists(), (
+        "custom hook body did not execute its side effect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_guard_plain_custom_orig_runs_alongside_husky_layout(isolated_env, tmp_path: Path):
+    """A custom .orig with no husky reference still runs when ``h`` exists."""
+    settings = get_settings()
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _init_git_repo(repo)
+
+    _write_husky_v9_layout(
+        repo,
+        "#!/usr/bin/env sh\necho HUSKY_TRACKED_RAN\n",
+        stub_body=(
+            "#!/usr/bin/env sh\n"
+            "echo PLAIN_CUSTOM_RAN\n"
+            'touch "$(git rev-parse --show-toplevel)/PLAIN_CUSTOM_RAN"\n'
+        ),
+    )
+    _git_config(repo, "core.hooksPath", ".husky/_")
+
+    hook_path = await install_guard(settings, "husky-v9-plain-custom", repo)
+
+    result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
+    assert result.returncode == 0, (
+        f"chain-runner failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "PLAIN_CUSTOM_RAN" in result.stdout
+    assert (repo / "PLAIN_CUSTOM_RAN").exists()
+    assert "HUSKY_TRACKED_RAN" not in result.stdout, (
+        "a custom hook must not be diverted through husky's resolver"
+    )
+
+
+@pytest.mark.asyncio
+async def test_guard_husky_stub_with_extra_statement_is_treated_as_custom(
+    isolated_env, tmp_path: Path
+):
+    """A failing custom body that also sources ``h`` must fail the commit.
+
+    Proves the misclassification is not merely cosmetic: when the custom body
+    is diverted away, a hook that should have BLOCKED the commit exits 0.
+    """
+    settings = get_settings()
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _init_git_repo(repo)
+
+    _write_husky_v9_layout(
+        repo,
+        "#!/usr/bin/env sh\necho HUSKY_TRACKED_RAN\n",
+        stub_body=(
+            "#!/usr/bin/env sh\n"
+            "echo CUSTOM_GATE_RAN\n"
+            "exit 42\n"
+            '. "$(dirname "$0")/h"\n'
+        ),
+    )
+    _git_config(repo, "core.hooksPath", ".husky/_")
+
+    hook_path = await install_guard(settings, "husky-v9-custom-gate", repo)
+
+    result = _run_hook(hook_path, repo, {"AGENT_NAME": "TestAgent", "WORKTREES_ENABLED": "1"})
+    assert "CUSTOM_GATE_RAN" in result.stdout, (
+        f"custom gate was skipped: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert result.returncode == 42, (
+        f"custom hook failure did not propagate: exit={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #264.

### The problem

The chain-runner rendered by `install_guard` classified the preserved `<hook>.orig` as a husky v9 stub with a bare substring test:

```python
return '/h"' in text
```

Any hook whose text mentions `.../h"` matched. A hand-written hook that does its own work **and** also sources husky's resolver — a common shape in repos that adopted husky on top of an existing hook — was therefore misclassified. `_run_orig` sourced `h` with `argv0` rewritten instead of exec'ing the `.orig`, and the user's entire custom body was silently discarded. A hook that should have blocked a bad commit exited 0 and the commit went through.

Same class of silent-skip failure the `argv0` diversion was introduced to eliminate, just relocated from husky's tracked hook onto the user's own.

### The change

A file counts as a husky stub only when it is *nothing but* a stub: an optional shebang, blank lines, `#` comments, and **exactly one** effective statement sourcing the sibling resolver `h`. Any extra command, or any second statement, means custom — exec it directly.

The statement is matched with a regex tolerating the spellings husky and hand-rolled equivalents emit: `.` vs `source`, double/single/absent quoting (backreferenced so quotes balance), `$(dirname "$0")` vs `${0%/*}`, `$0` vs `${0}`, an optional `--`, whitespace, and a trailing `;`. Stdlib-only; the pattern is embedded into the rendered runner via `repr()` so there is no escaping hazard.

The bias is deliberate: running a custom hook that also sources `h` is recoverable — husky's resolver just fails to match `.orig` and exits 0 — whereas silently dropping the user's hook is not. So anything unrecognised falls to CUSTOM.

I specifically kept husky's real `${0%/*}` spelling covered, since a too-tight regex would silently reintroduce the original bug this detector exists to avoid.

### Tests

Four tests added to `tests/test_guard_worktrees.py`, following the existing pytest-asyncio + real-git conventions and asserting observable behaviour (sentinel files, stdout, exit codes) rather than internals. `_write_husky_v9_layout` gains a keyword-only `stub_body=` override.

| Test | With this change | On current `main` |
|---|---|---|
| hybrid custom hook that also sources `h` still runs | pass | **fail** — body dropped |
| stub with an extra statement is treated as custom | pass | **fail** — exit 0 instead of 42 |
| stub detection accepts `${0%/*}` expansion | pass | pass (guard-rail) |
| plain custom `.orig` runs alongside husky layout | pass | pass (guard-rail) |

The second is the sharpest: a custom hook that should have blocked the commit with exit 42 exits 0 without it.

The hybrid test deliberately does not assert on statements *after* the source line — husky's resolver ends in `exit`, which terminates the sourcing script. That is inherent to sourcing `h`, not part of this bug.

Full run: **26 passed, 1 failed**. The failure is `test_guard_gate_worktrees_enabled_false`, which fails identically on pristine `main` in a clean worktree (`22 passed, 1 failed`, same `assert 1 == 0`) — pre-existing and unrelated. `ruff check` passes on both touched files.

### Notes

Found while tracing why a repo's `gitleaks` and `lint-staged` pre-commit gates had silently stopped running. That root cause was the original `basename($0)` bug, already fixed by 5f5644a — which I verified works end-to-end against real husky v9, including repairing an already-broken repo without manual cleanup. This PR only addresses the remaining detection looseness.

Happy to reshape this if you'd prefer a different approach.
